### PR TITLE
[MK8] Add "/meta/"less id, fullres alpha, MKTV, fix race end graphic

### DIFF
--- a/MK8_1080p/rules.txt
+++ b/MK8_1080p/rules.txt
@@ -1,16 +1,43 @@
 [Definition]
-titleIds = 000500001010ec00,0005000e1010ed00,0005000e1010eb00
-name = "Mario Kart 8 - 1080p"
+titleIds = 000500001010ec00,0005000e1010ed00,0005000e1010eb00,ffffffff85887bc1
+name = "Mario Kart 8 - 1080p (fullres alpha)"
 
-[TextureRedefine] # tv
+# Main Screen Resolution
+[TextureRedefine]
 width = 1280
 height = 720
-formatsExcluded = 0x41A # exclude the intro background texture
+formatsExcluded = 0x41A,0x431 # exclude the intro background texture, race end background
 overwriteWidth = 1920
 overwriteHeight = 1080
 
-[TextureRedefine] # gamepad
-width = 854
-height = 480
+# Half Res Alpha (and DOF)
+[TextureRedefine]
+width = 640
+height = 360
+formatsExcluded = 0x41A # exclude obvious textures
 overwriteWidth = 1920
 overwriteHeight = 1080
+
+# MKTV screen
+[TextureRedefine]
+width = 960
+height = 540
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 1440
+overwriteHeight = 810
+
+# MKTV internal render targets
+[TextureRedefine]
+width = 960
+height = 536
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 1440
+overwriteHeight = 810
+
+# MKTV half res alpha
+[TextureRedefine]
+width = 480
+height = 268
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 1440
+overwriteHeight = 810

--- a/MK8_1440p/rules.txt
+++ b/MK8_1440p/rules.txt
@@ -1,16 +1,43 @@
 [Definition]
-titleIds = 000500001010ec00,0005000e1010ed00,0005000e1010eb00
-name = "Mario Kart 8 - 1440p (2K)"
+titleIds = 000500001010ec00,0005000e1010ed00,0005000e1010eb00,ffffffff85887bc1
+name = "Mario Kart 8 - 1440p (fullres alpha)"
 
-[TextureRedefine] # tv
+# Main Screen Resolution
+[TextureRedefine]
 width = 1280
 height = 720
-formatsExcluded = 0x41A # exclude the intro background texture
+formatsExcluded = 0x41A,0x431 # exclude the intro background texture, race end background
 overwriteWidth = 2560
 overwriteHeight = 1440
 
-[TextureRedefine] # gamepad
-width = 854
-height = 480
+# Half Res Alpha (and DOF)
+[TextureRedefine]
+width = 640
+height = 360
+formatsExcluded = 0x41A # exclude obvious textures
 overwriteWidth = 2560
 overwriteHeight = 1440
+
+# MKTV screen
+[TextureRedefine]
+width = 960
+height = 540
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 1920
+overwriteHeight = 1080
+
+# MKTV internal render targets
+[TextureRedefine]
+width = 960
+height = 536
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 1920
+overwriteHeight = 1080
+
+# MKTV half res alpha
+[TextureRedefine]
+width = 480
+height = 268
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 1920
+overwriteHeight = 1080

--- a/MK8_2160p/rules.txt
+++ b/MK8_2160p/rules.txt
@@ -1,16 +1,43 @@
 [Definition]
-titleIds = 000500001010ec00,0005000e1010ed00,0005000e1010eb00
-name = "Mario Kart 8 - 2160p (4K)"
+titleIds = 000500001010ec00,0005000e1010ed00,0005000e1010eb00,ffffffff85887bc1
+name = "Mario Kart 8 - 2160p (4K fullres alpha)"
 
-[TextureRedefine] # tv
+# Main Screen Resolution
+[TextureRedefine]
 width = 1280
 height = 720
-formatsExcluded = 0x41A # exclude the intro background texture
+formatsExcluded = 0x41A,0x431 # exclude the intro background texture, race end background
 overwriteWidth = 3840
 overwriteHeight = 2160
 
-[TextureRedefine] # gamepad
-width = 854
-height = 480
+# Half Res Alpha (and DOF)
+[TextureRedefine]
+width = 640
+height = 360
+formatsExcluded = 0x41A # exclude obvious textures
 overwriteWidth = 3840
 overwriteHeight = 2160
+
+# MKTV output
+[TextureRedefine]
+width = 960
+height = 540
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 2880
+overwriteHeight = 1620
+
+# MKTV internal render targets
+[TextureRedefine]
+width = 960
+height = 536
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 2880
+overwriteHeight = 1620
+
+# MKTV half res alpha
+[TextureRedefine]
+width = 480
+height = 268
+formatsExcluded = 0x41A # exclude obvious textures
+overwriteWidth = 2880
+overwriteHeight = 1620


### PR DESCRIPTION
4K alpha (i'm using a 1080p monitor):
![image](https://cloud.githubusercontent.com/assets/6294155/21865500/4456b3b2-d83e-11e6-9cb1-18f8a7cca9ae.png)

4K in MKTV:
![image](https://cloud.githubusercontent.com/assets/6294155/21865443/083aa99c-d83e-11e6-9549-fddb390c43a5.png)

Excludes the format used by the backgrounds used at the end of VS Mode/Grand Prix, so they don't appear black.

Also ends up removing the gamepad rescale. I think that should be in a separate pack, as in most cases users won't be looking at the gamepad in this game, and rendering it at a higher res would just burn GPU cycles.