### PR TITLE
SM3DW+CT:TT half-res alpha, XCX GCN4 workaround

### DIFF
--- a/Preformance/SuperMario3DWorld_360p/rules.txt
+++ b/Preformance/SuperMario3DWorld_360p/rules.txt
@@ -5,9 +5,16 @@ name = "Super Mario 3D World + Captain Toad: Treasure Tracker - 360p"
 [TextureRedefine] # tv
 width = 1280
 height = 720
-formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture
+formatsExcluded = 0x008,0x41A,0x034,,0x035 # exclude the intro background texture,map
 overwriteWidth = 640
 overwriteHeight = 360
+
+[TextureRedefine] # half-res alpha
+width = 640
+height = 360
+formatsExcluded = 0x41A,0x034,0x035 # exclude obvious textures
+overwriteWidth = 320
+overwriteHeight = 180
 
 [TextureRedefine] # gamepad
 width = 854

--- a/Preformance/XCX_GCN4Workaround/rules
+++ b/Preformance/XCX_GCN4Workaround/rules
@@ -1,0 +1,8 @@
+titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
+name = "Xenoblade Chronicles X - AMD GCN4 Workaround"
+
+[TextureRedefine] # No artifacts
+width = 320
+height = 180
+overwriteWidth = 0
+overwriteHeight = 0

--- a/Quality/SuperMario3DWorld_1080p/rules.txt
+++ b/Quality/SuperMario3DWorld_1080p/rules.txt
@@ -5,6 +5,13 @@ name = "Super Mario 3D World + Captain Toad: Treasure Tracker - 1080p"
 [TextureRedefine] # tv
 width = 1280
 height = 720
-formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture
+formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture,map
 overwriteWidth = 1920
 overwriteHeight = 1080
+
+[TextureRedefine] # half-res alpha
+width = 640
+height = 360
+formatsExcluded = 0x41A,0x034,0x035 # exclude obvious textures
+overwriteWidth = 960
+overwriteHeight = 540

--- a/Quality/SuperMario3DWorld_1080p/rules.txt
+++ b/Quality/SuperMario3DWorld_1080p/rules.txt
@@ -5,7 +5,7 @@ name = "Super Mario 3D World + Captain Toad: Treasure Tracker - 1080p"
 [TextureRedefine] # tv
 width = 1280
 height = 720
-formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture,map
+formatsExcluded = 0x008,0x41A,0x034,0x035 # exclude the intro background texture,map
 overwriteWidth = 1920
 overwriteHeight = 1080
 

--- a/Quality/SuperMario3DWorld_1440p/rules.txt
+++ b/Quality/SuperMario3DWorld_1440p/rules.txt
@@ -5,6 +5,13 @@ name = "Super Mario 3D World + Captain Toad: Treasure Tracker - 1440p (2K)"
 [TextureRedefine] # tv
 width = 1280
 height = 720
-formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture
+formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture,map
 overwriteWidth = 2560
 overwriteHeight = 1440
+
+[TextureRedefine] # half-res alpha
+width = 640
+height = 360
+formatsExcluded = 0x41A,0x034,0x035 # exclude obvious textures
+overwriteWidth = 1280
+overwriteHeight = 720

--- a/Quality/SuperMario3DWorld_1440p/rules.txt
+++ b/Quality/SuperMario3DWorld_1440p/rules.txt
@@ -5,7 +5,7 @@ name = "Super Mario 3D World + Captain Toad: Treasure Tracker - 1440p (2K)"
 [TextureRedefine] # tv
 width = 1280
 height = 720
-formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture,map
+formatsExcluded = 0x008,0x41A,0x034,0x035 # exclude the intro background texture,map
 overwriteWidth = 2560
 overwriteHeight = 1440
 

--- a/Quality/SuperMario3DWorld_2160p/rules.txt
+++ b/Quality/SuperMario3DWorld_2160p/rules.txt
@@ -9,9 +9,7 @@ formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture
 overwriteWidth = 3840
 overwriteHeight = 2160
 
-
 [TextureRedefine] # half-res alpha
-
 width = 640
 height = 360
 formatsExcluded = 0x41A,0x034,0x035 # exclude obvious textures

--- a/Quality/SuperMario3DWorld_2160p/rules.txt
+++ b/Quality/SuperMario3DWorld_2160p/rules.txt
@@ -5,7 +5,7 @@ name = "Super Mario 3D World + Captain Toad: Treasure Tracker - 2160p (4K)"
 [TextureRedefine] # tv
 width = 1280
 height = 720
-formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture
+formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture,map
 overwriteWidth = 3840
 overwriteHeight = 2160
 

--- a/Quality/SuperMario3DWorld_2160p/rules.txt
+++ b/Quality/SuperMario3DWorld_2160p/rules.txt
@@ -8,3 +8,12 @@ height = 720
 formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture
 overwriteWidth = 3840
 overwriteHeight = 2160
+
+
+[TextureRedefine] # half-res alpha
+
+width = 640
+height = 360
+formatsExcluded = 0x41A,0x034,0x035 # exclude obvious textures
+overwriteWidth = 1920
+overwriteHeight = 1080

--- a/Quality/SuperMario3DWorld_2160p/rules.txt
+++ b/Quality/SuperMario3DWorld_2160p/rules.txt
@@ -5,7 +5,7 @@ name = "Super Mario 3D World + Captain Toad: Treasure Tracker - 2160p (4K)"
 [TextureRedefine] # tv
 width = 1280
 height = 720
-formatsExcluded = 0x008,0x41A,0x034 # exclude the intro background texture,map
+formatsExcluded = 0x008,0x41A,0x034,0x035 # exclude the intro background texture,map
 overwriteWidth = 3840
 overwriteHeight = 2160
 

--- a/Quality/XCX_GCN4Workaround/rules
+++ b/Quality/XCX_GCN4Workaround/rules
@@ -1,0 +1,8 @@
+titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
+name = "Xenoblade Chronicles X - AMD GCN4 Workaround"
+
+[TextureRedefine] # No artifacts
+width = 320
+height = 180
+overwriteWidth = 0
+overwriteHeight = 0

--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Splatoon
 
 - [Gamepad is blurry in Multiplayer](http://imgur.com/a/1YecH) (Quality - Gamepad)
 
-Super Mario 3D World + Captain Toad: Treasure Tracker
-
-- [Distortion filter doesn't render properly](http://i.imgur.com/LSaWMyN.jpg) (All)
-
 Super Mario Maker
 
 - [NSMBU theme is completely broken](http://i.imgur.com/OumJaa6.png) (Quality)


### PR DESCRIPTION
Fixed heatwaves in both SM3DW and Captain Toad:Treasure Tracker, also added workaround for no artifacts on AMD GCN4 GPUs. 

4K internal resolution SM3DW -
![hw3](https://cloud.githubusercontent.com/assets/25060470/21997058/cb7f7920-dbf2-11e6-8fa8-93bdaed9f57e.png)

4K internal resolution CT:TT-
![cthw-4k](https://cloud.githubusercontent.com/assets/25060470/21997061/d13bbcc0-dbf2-11e6-8e6b-780c4b41a988.png)