### PR TITLE
[Xenoblade X] Added equipment screen render

### DIFF
--- a/Quality/XCX_1080p/rules.txt
+++ b/Quality/XCX_1080p/rules.txt
@@ -14,3 +14,9 @@ height = 360
 formatsExcluded = 0x41A # exclude obvious textures
 overwriteWidth = 960
 overwriteHeight = 540
+
+[TextureRedefine] # Gear menu
+width = 1024
+height = 720
+overwriteWidth = 1536
+overwriteHeight = 1080

--- a/Quality/XCX_1440p/rules.txt
+++ b/Quality/XCX_1440p/rules.txt
@@ -14,3 +14,9 @@ height = 360
 formatsExcluded = 0x41A # exclude obvious textures
 overwriteWidth = 1280
 overwriteHeight = 720
+
+[TextureRedefine] # Gear menu
+width = 1024
+height = 720
+overwriteWidth = 2048
+overwriteHeight = 1440

--- a/Quality/XCX_2160p/rules.txt
+++ b/Quality/XCX_2160p/rules.txt
@@ -14,3 +14,9 @@ height = 360
 formatsExcluded = 0x41A # exclude obvious textures
 overwriteWidth = 1920
 overwriteHeight = 1080
+
+[TextureRedefine] # Gear menu
+width = 1024
+height = 720
+overwriteWidth = 4096
+overwriteHeight = 2160


### PR DESCRIPTION
It's rendered at 1024x720, so it needed a seperate overwrite. Seems to work fine. 