### PR TITLE
XCX probe and dialog fix

### DIFF
--- a/Enthusiast/XCX_2880p/rules.txt
+++ b/Enthusiast/XCX_2880p/rules.txt
@@ -11,7 +11,7 @@ overwriteHeight = 2880
 [TextureRedefine] # half-res alpha
 width = 640
 height = 360
-formatsExcluded = 0x41A # exclude obvious textures
+formatsExcluded = 0x41A, 0x033, 0x001  # exclude obvious textures, dialog fade screen,  Intro movie partial fix 
 overwriteWidth = 2560
 overwriteHeight = 1440
 
@@ -33,11 +33,11 @@ height = 240
 overwriteWidth = 1704
 overwriteHeight = 960
 
-[TextureRedefine] # gamepad
+[TextureRedefine] # gamepad, scale in proportion to tv or probe list view breaks
 width = 854
 height = 480
-overwriteWidth = 2560
-overwriteHeight = 1440
+overwriteWidth = 3413
+overwriteHeight = 1920
 
 // vvvv credits to Getdls & GITech vvvv //
 

--- a/Enthusiast/XCX_4320p/rules.txt
+++ b/Enthusiast/XCX_4320p/rules.txt
@@ -11,7 +11,7 @@ overwriteHeight = 4320
 [TextureRedefine] # half-res alpha
 width = 640
 height = 360
-formatsExcluded = 0x41A # exclude obvious textures
+formatsExcluded = 0x41A, 0x033, 0x001  # exclude obvious textures, dialog fade screen,  Intro movie partial fix 
 overwriteWidth = 3840
 overwriteHeight = 2560
 
@@ -33,11 +33,11 @@ height = 240
 overwriteWidth = 2556
 overwriteHeight = 1440
 
-[TextureRedefine] # gamepad
+[TextureRedefine] # gamepad,  Scale proprotionally or probe list view breaks
 width = 854
 height = 480
-overwriteWidth = 2562
-overwriteHeight = 1440
+overwriteWidth = 5120
+overwriteHeight = 2880
 
 // vvvv credits to Getdls & GITech vvvv //
 

--- a/Quality/GhostBladeHD_2160p/rules.txt
+++ b/Quality/GhostBladeHD_2160p/rules.txt
@@ -1,0 +1,15 @@
+[Definition]# USA title		# Set GPU buffer accuracy to High
+titleIds = 50000101ffc00 #		
+name = "Ghost Blade HD  - 3x scale (2160p)" #		
+		
+[TextureRedefine] # internal resolution x3
+width =	1280	#
+height = 	720	#
+overwriteWidth = 	3840	#
+overwriteHeight = 	2160	#
+
+[TextureRedefine] # gamepad view resolution. No point in rendering, just mirrors screen. 
+width =	854	#
+height =	480	#
+overwriteWidth =	256 #Nearest integer
+overwriteHeight =	144	#


### PR DESCRIPTION
FIX Dialog will fade instead of black screen
FIX Gamepad probe no longer breaks
FIX Intro movie plays instead of green screen. Decoding is mostly broken