### PR TITLE
Ultra wide patches for SM3dW/Kinopio

### DIFF
--- a/Quality/SuperMario3DWorld_1080pUW/patches.txt
+++ b/Quality/SuperMario3DWorld_1080pUW/patches.txt
@@ -1,0 +1,38 @@
+[RedProAspectUW]
+moduleMatches = 0xBBAF1908
+# rodata constants
+0x10363ED4 = .float 2.370
+0x1036A688 = .float 2.370
+_aspectAddr = 0x10363ED4
+
+# Aspect calculation
+0x0241D9B4 = lis r8, _aspectAddr@ha
+0x0241D9B8 = lfs f0, _aspectAddr@l(r8)
+
+
+[KinopioAspectUW]
+moduleMatches = 0x43781F76
+#rodata constants
+0x100A0EE0 = .float 2.370
+0x100BE2EC = .float 2.370
+0x100D79B4 = .float 2.370
+_aspectAddr = 0x100A0EE0
+
+#Aspect Calculation
+0x02368158 = lis r31, _aspectAddr@ha
+0x0236815c = lfs f13, _aspectAddr@l(r31)
+
+
+
+[KinopioAspectUWv16]
+moduleMatches = 0x9E0461E7
+#rodata constants
+0x0100A2D38 = .float 2.370
+0x0100C0164 = .float 2.370
+0x0100D982C = .float 2.370
+_aspectAddr = 0x0100A2D38
+
+#Aspect Calculation
+0x02373530 = lis r31, _aspectAddr@ha
+0x02373534 = lfs f13, _aspectAddr@l(r31)
+


### PR DESCRIPTION
Patches.txt for SM3dW and Captain Toad.  I didn't include the gamepad aspect because I didn't see any difference with it changed.  For 1440p UW all floats need to be changed to 2.388.