### PR TITLE
Updating MK8 UW patches

### DIFF
--- a/Quality/MK8_1080pUW/patches.txt
+++ b/Quality/MK8_1080pUW/patches.txt
@@ -59,7 +59,27 @@ _scaleAddr = 0x00000000
 0x024642E8 = bla _scaleAspect
 
 [MK8AspectVer4]
-moduleMatches = 0x1D398493, 0xD09700CE
+moduleMatches = 0x1D398493
+0x100C359C = .float 2.370
+0x10121D30 = .float 2.370
+
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x024AEBEC = bla _scaleAspect
+
+[MK8AspectVer4.1]
+moduleMatches = 0xD09700CE
 0x100C359C = .float 2.370
 0x10121E30 = .float 2.370
 

--- a/Quality/MK8_1080pUW/patches.txt
+++ b/Quality/MK8_1080pUW/patches.txt
@@ -2,34 +2,78 @@
 moduleMatches = 0x2A2DC82C
 0x10097D94 = .float 2.370
 0x100F3430 = .float 2.370
-_aspectAddr = 0x10097D94
 
-0x02416758 = lis r7, _aspectAddr@ha
-0x02416760 = lfs f7, _aspectAddr@l(r7)
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x02416760 = bla _scaleAspect
 
 [MK8AspectVer2]
 moduleMatches = 0x62A5F023
 0x1009E9DC = .float 2.370
 0x100FC030 = .float 2.370
-_aspectAddr = 0x1009E9DC
 
-0x024376CC = lis r7, _aspectAddr@ha
-0x024376D4 = lfs f7, _aspectAddr@l(r7)
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x024376D4 = bla _scaleAspect
 
 [MK8AspectVer3]
 moduleMatches = 0xBA6B1E20
 0x100AC25C = .float 2.370
 0x1010A730 = .float 2.370
-_aspectAddr = 0x100AC25C
 
-0x024642E0 = lis r7, _aspectAddr@ha
-0x024642E8 = lfs f7, _aspectAddr@l(r7)
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x024642E8 = bla _scaleAspect
 
 [MK8AspectVer4]
 moduleMatches = 0x1D398493, 0xD09700CE
 0x100C359C = .float 2.370
-0x10121D30 = .float 2.370
-_aspectAddr = 0x100C359C
+0x10121E30 = .float 2.370
 
-0x024AEBE4 = lis r7, _aspectAddr@ha
-0x024AEBEC = lfs f7, _aspectAddr@l(r7)
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x024AEBEC = bla _scaleAspect

--- a/Quality/MK8_2160pUW/patches.txt
+++ b/Quality/MK8_2160pUW/patches.txt
@@ -59,7 +59,27 @@ _scaleAddr = 0x00000000
 0x024642E8 = bla _scaleAspect
 
 [MK8AspectVer4]
-moduleMatches = 0x1D398493, 0xD09700CE
+moduleMatches = 0x1D398493
+0x100C359C = .float 2.370
+0x10121D30 = .float 2.370
+
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x024AEBEC = bla _scaleAspect
+
+[MK8AspectVer4.1]
+moduleMatches = 0xD09700CE
 0x100C359C = .float 2.370
 0x10121E30 = .float 2.370
 

--- a/Quality/MK8_2160pUW/patches.txt
+++ b/Quality/MK8_2160pUW/patches.txt
@@ -2,34 +2,78 @@
 moduleMatches = 0x2A2DC82C
 0x10097D94 = .float 2.370
 0x100F3430 = .float 2.370
-_aspectAddr = 0x10097D94
 
-0x02416758 = lis r7, _aspectAddr@ha
-0x02416760 = lfs f7, _aspectAddr@l(r7)
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x02416760 = bla _scaleAspect
 
 [MK8AspectVer2]
 moduleMatches = 0x62A5F023
 0x1009E9DC = .float 2.370
 0x100FC030 = .float 2.370
-_aspectAddr = 0x1009E9DC
 
-0x024376CC = lis r7, _aspectAddr@ha
-0x024376D4 = lfs f7, _aspectAddr@l(r7)
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x024376D4 = bla _scaleAspect
 
 [MK8AspectVer3]
 moduleMatches = 0xBA6B1E20
 0x100AC25C = .float 2.370
 0x1010A730 = .float 2.370
-_aspectAddr = 0x100AC25C
 
-0x024642E0 = lis r7, _aspectAddr@ha
-0x024642E8 = lfs f7, _aspectAddr@l(r7)
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x024642E8 = bla _scaleAspect
 
 [MK8AspectVer4]
 moduleMatches = 0x1D398493, 0xD09700CE
 0x100C359C = .float 2.370
-0x10121D30 = .float 2.370
-_aspectAddr = 0x100C359C
+0x10121E30 = .float 2.370
 
-0x024AEBE4 = lis r7, _aspectAddr@ha
-0x024AEBEC = lfs f7, _aspectAddr@l(r7)
+#aspect scaling
+codeCaveSize = 0x18
+
+_scaleAspect = 0x00000004
+0x00000000 = .float 1.333333
+_scaleAddr = 0x00000000
+0x00000004 = fdivs f9, f13, f12
+0x00000008 = lis r7, _scaleAddr@ha
+0x0000000C = lfs f12, _scaleAddr@l(r7)
+0x00000010 = fmuls f7, f9, f12
+0x00000014 = blr
+
+#replace math with branch
+0x024AEBEC = bla _scaleAspect


### PR DESCRIPTION
Altered the way the aspect ratio is changed for ultrawide packs.  This method corrects the aspect ratio for two player split screen and 3d models on the multiplayer select screen.  Though the latter was close enough that most people probably didn't notice.   This addresses the other half of issue #74 even though it's already closed.

Also separated v4 and v4.1 due to one of the rodata constants being 0x10 off.  Not sure if that could have caused any problems or not.