### PR TITLE
Fixed Breath of the Wild AARemoval in inventory screen

### DIFF
--- a/Enhancement/BreathOfTheWild_AARemoval/0f2b9ee517917425_00000000000003c9_ps.txt
+++ b/Enhancement/BreathOfTheWild_AARemoval/0f2b9ee517917425_00000000000003c9_ps.txt
@@ -1,0 +1,649 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+// shader 0f2b9ee517917425
+uniform ivec4 uf_remappedPS[2];
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf49b1800 res 1280x720x1 dim 1 tm: 4 format 0019 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
+layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x38784000 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 1
+layout(location = 0) in vec4 passParameterSem2;
+layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+bool activeMaskStack[2];
+bool activeMaskStackC[3];
+activeMaskStack[0] = false;
+activeMaskStackC[0] = false;
+activeMaskStackC[1] = false;
+activeMaskStack[0] = true;
+activeMaskStackC[0] = true;
+activeMaskStackC[1] = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = floatBitsToInt(passParameterSem2);
+if( activeMaskStackC[1] == true ) {
+//R2i.xzw = floatBitsToInt(textureGather(textureUnitPS1, intBitsToFloat(R0i.xy)).xzw);
+//R1i.xz = floatBitsToInt(textureGather(textureUnitPS1, intBitsToFloat(R0i.zw)).xz);
+R3i.xyzw = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R0i.xy)).xyzw);
+R0i.w = floatBitsToInt(textureOffset(textureUnitPS1, intBitsToFloat(R0i.xy),ivec2(1,-1)).x);
+R1i.y = floatBitsToInt(textureOffset(textureUnitPS1, intBitsToFloat(R0i.xy),ivec2(-1,1)).x);
+}
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+PV0i.x = floatBitsToInt(min(intBitsToFloat(R1i.x), intBitsToFloat(R1i.z)));
+PV0i.y = floatBitsToInt(max(intBitsToFloat(R2i.x), intBitsToFloat(R2i.z)));
+PV0i.z = floatBitsToInt(max(intBitsToFloat(R1i.x), intBitsToFloat(R1i.z)));
+PV0i.w = floatBitsToInt(min(intBitsToFloat(R2i.x), intBitsToFloat(R2i.z)));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.z), intBitsToFloat(PV0i.y)));
+PV1i.y = floatBitsToInt(min(intBitsToFloat(PV0i.x), intBitsToFloat(PV0i.w)));
+// 2
+PV0i.z = floatBitsToInt(min(intBitsToFloat(R2i.w), intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(max(intBitsToFloat(R2i.w), intBitsToFloat(PV1i.x)));
+// 3
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(uf_remappedPS[0].x)));
+R1i.w = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.z)));
+// 4
+R2i.y = floatBitsToInt(max(intBitsToFloat(PV1i.x), intBitsToFloat(uf_remappedPS[0].y)));
+// 5
+predResult = (intBitsToFloat(R1i.w) >= intBitsToFloat(R2i.y));
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R126i.xyz = floatBitsToInt(vec3(intBitsToFloat(R2i.z),intBitsToFloat(R1i.x),intBitsToFloat(R2i.z)) + vec3(intBitsToFloat(R0i.w),intBitsToFloat(R1i.y),intBitsToFloat(R1i.x)));
+PV0i.z = R126i.z;
+R127i.w = floatBitsToInt(intBitsToFloat(R2i.x) + intBitsToFloat(R1i.z));
+PV0i.w = R127i.w;
+R127i.y = R1i.z;
+R127i.y = floatBitsToInt(intBitsToFloat(R127i.y) * 2.0);
+PS0i = R127i.y;
+// 1
+PV1i.x = R2i.x;
+PV1i.x = floatBitsToInt(intBitsToFloat(PV1i.x) * 2.0);
+PV1i.y = floatBitsToInt(intBitsToFloat(R1i.x) + intBitsToFloat(R0i.w));
+R127i.z = floatBitsToInt((-(intBitsToFloat(R2i.w)) * 2.0 + intBitsToFloat(PV0i.z)));
+PV1i.w = PV0i.w;
+PS1i = floatBitsToInt(intBitsToFloat(R2i.z) + intBitsToFloat(R1i.y));
+// 2
+R127i.x = floatBitsToInt((-(intBitsToFloat(R2i.w)) * 2.0 + intBitsToFloat(PV1i.w)));
+R1i.y = R2i.z;
+PV0i.y = R1i.y;
+PV0i.z = floatBitsToInt(intBitsToFloat(PS1i) + -(intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(R127i.y)));
+PS0i = R126i.x;
+// 3
+backupReg0i = R127i.z;
+backupReg0i = R127i.z;
+R123i.x = floatBitsToInt((-(intBitsToFloat(R1i.x)) * 2.0 + intBitsToFloat(R126i.y)));
+PV1i.x = R123i.x;
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+R127i.z = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+R123i.w = floatBitsToInt((-(intBitsToFloat(PV0i.y)) * 2.0 + intBitsToFloat(PS0i)));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(max(intBitsToFloat(backupReg0i), -(intBitsToFloat(backupReg0i))));
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) * 2.0);
+// 4
+backupReg0i = R126i.y;
+PV0i.x = floatBitsToInt(max(intBitsToFloat(PV1i.x), -(intBitsToFloat(PV1i.x))));
+R126i.y = floatBitsToInt(max(intBitsToFloat(PV1i.w), -(intBitsToFloat(PV1i.w))));
+PV0i.z = floatBitsToInt(max(intBitsToFloat(R127i.x), -(intBitsToFloat(R127i.x))));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + intBitsToFloat(PS1i));
+R126i.w = floatBitsToInt(intBitsToFloat(R126i.x) + intBitsToFloat(backupReg0i));
+PS0i = R126i.w;
+// 5
+backupReg0i = R127i.z;
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + intBitsToFloat(PV0i.z));
+PV1i.y = floatBitsToInt(intBitsToFloat(R127i.w) + intBitsToFloat(R126i.z));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV1i.y) * 2.0);
+R127i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.w));
+R127i.y = floatBitsToInt(1.0 / intBitsToFloat(R1i.w));
+PS1i = R127i.y;
+// 6
+PV0i.x = floatBitsToInt(intBitsToFloat(R126i.w) + intBitsToFloat(PV1i.y));
+PV0i.y = floatBitsToInt(intBitsToFloat(R126i.y) + intBitsToFloat(PV1i.x));
+// 7
+PV1i.x = ((intBitsToFloat(PV0i.y) >= intBitsToFloat(R127i.z))?int(0xFFFFFFFF):int(0x0));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.x) * intBitsToFloat(0x3daaaaab));
+// 8
+PV0i.x = floatBitsToInt(intBitsToFloat(R2i.w) + -(intBitsToFloat(PV1i.y)));
+R4i.z = ((PV1i.x == 0)?(0x3f800000):(0));
+PV0i.z = R4i.z;
+R5i.w = ((PV1i.x == 0)?(0):(0x3f800000));
+PV0i.w = R5i.w;
+// 9
+R5i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(uf_remappedPS[1].x)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), intBitsToFloat(uf_remappedPS[1].x)));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+R3i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), intBitsToFloat(uf_remappedPS[1].y)));
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.x), intBitsToFloat(PV0i.z)));
+// 10
+R127i.x = floatBitsToInt(intBitsToFloat(PV1i.z) * intBitsToFloat(R127i.y));
+R127i.x = clampFI32(R127i.x);
+PV0i.x = R127i.x;
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(uf_remappedPS[1].y)) + intBitsToFloat(PV1i.y)));
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.z),intBitsToFloat(R5i.w)) + intBitsToFloat(PS1i)));
+PV0i.z = R127i.z;
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.z), intBitsToFloat(R4i.z)));
+// 11
+R124i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.x),intBitsToFloat(R5i.w)) + intBitsToFloat(PV0i.w)));
+PV1i.x = R124i.x;
+PV1i.y = floatBitsToInt(-(intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.z));
+R123i.w = floatBitsToInt((intBitsToFloat(PV0i.x) * intBitsToFloat(0x40c00000) + intBitsToFloat(0xc1700000)));
+PV1i.w = R123i.w;
+// 12
+R125i.x = floatBitsToInt(max(intBitsToFloat(PV1i.y), -(intBitsToFloat(PV1i.y))));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R2i.w)) + intBitsToFloat(PV1i.x));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(PV1i.w)) + intBitsToFloat(0x41200000)));
+PV0i.z = R123i.z;
+// 13
+R126i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.x = R126i.x;
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV0i.z)));
+// 14
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV1i.y)));
+R126i.w = ((intBitsToFloat(R125i.x) >= intBitsToFloat(PV1i.x))?int(0xFFFFFFFF):int(0x0));
+PV0i.w = R126i.w;
+// 15
+R6i.x = floatBitsToInt(((PV0i.w == 0)?(intBitsToFloat(R127i.y)):(-(intBitsToFloat(R127i.y)))));
+PV1i.x = R6i.x;
+R123i.z = ((PV0i.w == 0)?(R126i.x):(R125i.x));
+PV1i.z = R123i.z;
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV0i.x)));
+// 16
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R4i.z), intBitsToFloat(PV1i.x)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) / 2.0);
+R123i.y = ((R126i.w == 0)?(R124i.x):(R127i.z));
+PV0i.y = R123i.y;
+R3i.z = floatBitsToInt(intBitsToFloat(PV1i.w) * intBitsToFloat(0x3f400000));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.w), intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) / 2.0);
+R4i.x = floatBitsToInt(intBitsToFloat(PV1i.z) * 0.25);
+PS0i = R4i.x;
+// 17
+backupReg0i = R0i.x;
+PV1i.x = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.x));
+PV1i.z = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(PV0i.w));
+R4i.w = floatBitsToInt(intBitsToFloat(R2i.w) + intBitsToFloat(PV0i.y));
+R4i.w = floatBitsToInt(intBitsToFloat(R4i.w) / 2.0);
+PV1i.w = R4i.w;
+// 18
+R3i.x = floatBitsToInt(-(intBitsToFloat(R5i.x)) + intBitsToFloat(PV1i.x));
+R3i.y = floatBitsToInt(-(intBitsToFloat(R3i.w)) + intBitsToFloat(PV1i.z));
+R1i.z = floatBitsToInt(intBitsToFloat(R5i.x) + intBitsToFloat(PV1i.x));
+R1i.w = floatBitsToInt(intBitsToFloat(R3i.w) + intBitsToFloat(PV1i.z));
+R2i.x = floatBitsToInt(intBitsToFloat(R2i.w) + -(intBitsToFloat(PV1i.w)));
+PS0i = R2i.x;
+}
+if( activeMaskStackC[2] == true ) {
+R1i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+backupReg0i = R2i.x;
+R2i.x = ((0.0 > intBitsToFloat(backupReg0i))?int(0xFFFFFFFF):int(0x0));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.x));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.y));
+// 1
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+backupReg0i = R3i.x;
+backupReg1i = R3i.y;
+R3i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.w)) + intBitsToFloat(backupReg0i)));
+R3i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.w)) + intBitsToFloat(backupReg1i)));
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(R1i.z)));
+R2i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(R1i.w)));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.w));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.z));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+backupReg0i = R2i.z;
+backupReg1i = R2i.w;
+R1i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.w)) + intBitsToFloat(R3i.x)));
+R1i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.w)) + intBitsToFloat(R3i.y)));
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg0i)));
+R2i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R3i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R3i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.x));
+// 1
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+// 3
+R123i.y = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.y = R123i.y;
+R123i.z = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+// 4
+backupReg0i = R1i.x;
+backupReg1i = R1i.y;
+R1i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg0i)));
+R1i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg1i)));
+R1i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(R2i.z)));
+R1i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(R2i.w)));
+}
+if( activeMaskStackC[2] == true ) {
+R2i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R2i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.w));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.z));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+backupReg0i = R1i.z;
+backupReg1i = R1i.w;
+R3i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.w)) + intBitsToFloat(R1i.x)));
+R3i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.w)) + intBitsToFloat(R1i.y)));
+R1i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg0i)));
+R1i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.x));
+// 1
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+// 3
+R123i.y = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.y = R123i.y;
+R123i.z = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+// 4
+backupReg0i = R3i.x;
+backupReg1i = R3i.y;
+R3i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.x)),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg0i)));
+R3i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg1i)));
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(R1i.z)));
+R2i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(R1i.w)));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.w));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.z));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.w = floatBitsToInt(max(intBitsToFloat(PV0i.x), -(intBitsToFloat(PV0i.x))));
+// 2
+PV0i.z = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.z)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+// 5
+backupReg0i = R2i.z;
+backupReg1i = R2i.w;
+R1i.x = floatBitsToInt((-(intBitsToFloat(PV0i.x)) * 1.5 + intBitsToFloat(R3i.x)));
+R1i.y = floatBitsToInt((-(intBitsToFloat(PV0i.w)) * 1.5 + intBitsToFloat(R3i.y)));
+R2i.z = floatBitsToInt((intBitsToFloat(PV0i.z) * 1.5 + intBitsToFloat(backupReg0i)));
+R2i.w = floatBitsToInt((intBitsToFloat(PV0i.y) * 1.5 + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R3i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R3i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.x));
+// 1
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+// 3
+R123i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R123i.x;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.x)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 2.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 2.0);
+// 5
+backupReg0i = R1i.x;
+backupReg1i = R1i.y;
+R1i.xyz = floatBitsToInt(vec3(intBitsToFloat(backupReg0i),intBitsToFloat(backupReg1i),intBitsToFloat(R2i.z)) + vec3(-(intBitsToFloat(PV0i.w)),-(intBitsToFloat(PV0i.z)),intBitsToFloat(PV0i.x)));
+R1i.w = floatBitsToInt(intBitsToFloat(R2i.w) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R2i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R2i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.z));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.w));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 2.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.z)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 2.0);
+// 5
+backupReg0i = R1i.z;
+backupReg1i = R1i.w;
+R3i.x = floatBitsToInt(intBitsToFloat(R1i.x) + -(intBitsToFloat(PV0i.x)));
+R3i.y = floatBitsToInt(intBitsToFloat(R1i.y) + -(intBitsToFloat(PV0i.w)));
+R1i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.z));
+R1i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.x));
+// 1
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+// 3
+R123i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R123i.x;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.x)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 2.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 2.0);
+// 5
+backupReg0i = R3i.x;
+backupReg1i = R3i.y;
+R3i.x = floatBitsToInt(intBitsToFloat(backupReg0i) + -(intBitsToFloat(PV0i.w)));
+R3i.y = floatBitsToInt(intBitsToFloat(backupReg1i) + -(intBitsToFloat(PV0i.z)));
+R2i.z = floatBitsToInt(intBitsToFloat(R1i.z) + intBitsToFloat(PV0i.x));
+R2i.w = floatBitsToInt(intBitsToFloat(R1i.w) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R3i.xy)).x);
+R1i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.z));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.w));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 2.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.z)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 2.0);
+// 5
+backupReg0i = R2i.z;
+backupReg1i = R2i.w;
+R1i.x = floatBitsToInt(intBitsToFloat(R3i.x) + -(intBitsToFloat(PV0i.x)));
+R1i.y = floatBitsToInt(intBitsToFloat(R3i.y) + -(intBitsToFloat(PV0i.w)));
+R2i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.z));
+R2i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R3i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R3i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R2i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R3i.x));
+// 1
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+PV1i.z = floatBitsToInt(max(intBitsToFloat(PV0i.w), -(intBitsToFloat(PV0i.w))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.z)));
+// 3
+R123i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R123i.x;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.x)));
+PV0i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * 4.0);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 4.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 4.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV0i.w) * 4.0);
+// 5
+backupReg0i = R1i.x;
+backupReg1i = R1i.y;
+R1i.xyz = floatBitsToInt(vec3(intBitsToFloat(backupReg0i),intBitsToFloat(backupReg1i),intBitsToFloat(R2i.z)) + vec3(-(intBitsToFloat(PV0i.w)),-(intBitsToFloat(PV0i.z)),intBitsToFloat(PV0i.x)));
+R1i.w = floatBitsToInt(intBitsToFloat(R2i.w) + intBitsToFloat(PV0i.y));
+}
+if( activeMaskStackC[2] == true ) {
+R2i.w = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.xy)).x);
+R2i.z = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.z));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R2i.w));
+// 1
+PV1i.x = floatBitsToInt(max(intBitsToFloat(PV0i.y), -(intBitsToFloat(PV0i.y))));
+PV1i.y = floatBitsToInt(max(intBitsToFloat(PV0i.z), -(intBitsToFloat(PV0i.z))));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R4i.x) + -(intBitsToFloat(PV1i.x)));
+// 3
+R123i.z = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R123i.z;
+R123i.w = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.w)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV1i.z)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.z)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(PV1i.w)));
+// 5
+backupReg0i = R1i.z;
+backupReg1i = R1i.w;
+R5i.x = floatBitsToInt((-(intBitsToFloat(PV0i.x)) * intBitsToFloat(0x41000000) + intBitsToFloat(R1i.x)));
+R5i.y = floatBitsToInt((-(intBitsToFloat(PV0i.w)) * intBitsToFloat(0x41000000) + intBitsToFloat(R1i.y)));
+R1i.z = floatBitsToInt((intBitsToFloat(PV0i.y) * intBitsToFloat(0x41000000) + intBitsToFloat(backupReg0i)));
+R1i.w = floatBitsToInt((intBitsToFloat(PV0i.z) * intBitsToFloat(0x41000000) + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R1i.y = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R5i.xy)).x);
+R1i.x = floatBitsToInt(texture(textureUnitPS1, intBitsToFloat(R1i.zw)).x);
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+backupReg0i = R0i.x;
+backupReg1i = R0i.y;
+backupReg0i = R0i.x;
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.x));
+PV0i.y = floatBitsToInt(intBitsToFloat(backupReg0i) + -(intBitsToFloat(R5i.x)));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R4i.w)) + intBitsToFloat(R1i.y));
+R126i.w = floatBitsToInt(intBitsToFloat(backupReg1i) + -(intBitsToFloat(R5i.y)));
+PS0i = floatBitsToInt(-(intBitsToFloat(backupReg0i)) + intBitsToFloat(R1i.z));
+// 1
+PV1i.x = floatBitsToInt(-(intBitsToFloat(R0i.y)) + intBitsToFloat(R1i.w));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.w), intBitsToFloat(PS0i)));
+PV1i.z = ((0.0 > intBitsToFloat(PV0i.z))?int(0xFFFFFFFF):int(0x0));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.w), intBitsToFloat(PV0i.y)));
+PS1i = ((0.0 > intBitsToFloat(PV0i.x))?int(0xFFFFFFFF):int(0x0));
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.z),intBitsToFloat(PV1i.x)) + intBitsToFloat(PV1i.y)));
+PV0i.x = R123i.x;
+R127i.y = (PV1i.z != R2i.x)?int(0xFFFFFFFF):int(0x0);
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.z),intBitsToFloat(R126i.w)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+R126i.w = (PS1i != R2i.x)?int(0xFFFFFFFF):int(0x0);
+// 3
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.z) + intBitsToFloat(PV0i.x));
+R126i.y = floatBitsToInt(min(intBitsToFloat(PV0i.z), intBitsToFloat(PV0i.x)));
+PV1i.z = ((intBitsToFloat(PV0i.x) > intBitsToFloat(PV0i.z))?int(0xFFFFFFFF):int(0x0));
+// 4
+backupReg0i = R127i.y;
+R127i.y = ((PV1i.z == 0)?(R126i.w):(backupReg0i));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+// 5
+PV1i.z = floatBitsToInt(intBitsToFloat(R126i.y) * intBitsToFloat(PS0i));
+// 6
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 0.5);
+// 7
+R123i.x = ((R127i.y == 0)?(0):(PV0i.y));
+PV1i.x = R123i.x;
+// 8
+PV0i.w = floatBitsToInt(max(intBitsToFloat(R3i.z), intBitsToFloat(PV1i.x)));
+// 9
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.x), intBitsToFloat(PV0i.w)));
+// 10
+backupReg0i = R0i.x;
+backupReg1i = R0i.y;
+R0i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.z),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg0i)));
+R0i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg1i)));
+}
+if( activeMaskStackC[2] == true ) {
+R3i.xyzw = floatBitsToInt(texture(textureUnitPS0, intBitsToFloat(R0i.xy)).xyzw);
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+// export
+passPixelColor0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+}


### PR DESCRIPTION
When using the 4k and AARemoval pack, the inventory screen still shows broken antialiasing
I might have found a solution for it. Let me know if this doesn't only happen for me, and I'll do a pull request
Here are some examples.
![aabrokendetail](https://user-images.githubusercontent.com/6061770/30722895-4d8e0b36-9f3c-11e7-9f47-aa390ca123ee.png)
![aafixeddetail](https://user-images.githubusercontent.com/6061770/30722899-5218a35a-9f3c-11e7-92da-0dad149fe669.png)
Cropped from 4k, resized 2x with no filter, for the love of pixels