### PR TITLE
workaround upscaled blur pixelation

### DIFF
--- a/Enthusiast/BreathOfTheWild_2880p/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Enthusiast/BreathOfTheWild_2880p/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 2880
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.11011604, 0.20071416, 0.13842356, 0.07060718, 0.02643049, 0.00717399, 0.00138786, 0.00018683, 0.00001693, 0.00000098 );
+uniform float offset[] = float[]( 0.00000000, 1.47169811, 3.43396226, 5.39622642, 7.35849057, 9.32075472, 11.28301887, 13.24528302, 15.20754717, 17.16981132 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<10; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(0.0, offset[i]*h) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(0.0, offset[i]*h) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }

--- a/Enthusiast/BreathOfTheWild_2880p/6279271034da8f93_0000000000000079_ps.txt
+++ b/Enthusiast/BreathOfTheWild_2880p/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 5120
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.11011604, 0.20071416, 0.13842356, 0.07060718, 0.02643049, 0.00717399, 0.00138786, 0.00018683, 0.00001693, 0.00000098 );
+uniform float offset[] = float[]( 0.00000000, 1.47169811, 3.43396226, 5.39622642, 7.35849057, 9.32075472, 11.28301887, 13.24528302, 15.20754717, 17.16981132 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<10; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(offset[i]*w, 0.0) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(offset[i]*w, 0.0) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
+
+//py blurninja.py --expand 8 --reduce 8 37 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Enthusiast/BreathOfTheWild_4320p/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Enthusiast/BreathOfTheWild_4320p/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 4320
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.08679764, 0.16377778, 0.12975631, 0.08523885, 0.04634210, 0.02079453, 0.00767262, 0.00231673, 0.00056902, 0.00011284, 0.00001790, 0.00000225, 0.00000022, 0.00000002 );
+uniform float offset[] = float[]( 0.00000000, 1.48235294, 3.45882353, 5.43529412, 7.41176471, 9.38823529, 11.36470588, 13.34117647, 15.31764706, 17.29411765, 19.27058824, 21.24705882, 23.22352941, 25.20000000 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<14; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(0.0, offset[i]*h) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(0.0, offset[i]*h) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }

--- a/Enthusiast/BreathOfTheWild_4320p/6279271034da8f93_0000000000000079_ps.txt
+++ b/Enthusiast/BreathOfTheWild_4320p/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 7680
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.08679764, 0.16377778, 0.12975631, 0.08523885, 0.04634210, 0.02079453, 0.00767262, 0.00231673, 0.00056902, 0.00011284, 0.00001790, 0.00000225, 0.00000022, 0.00000002 );
+uniform float offset[] = float[]( 0.00000000, 1.48235294, 3.45882353, 5.43529412, 7.41176471, 9.38823529, 11.36470588, 13.34117647, 15.31764706, 17.29411765, 19.27058824, 21.24705882, 23.22352941, 25.20000000 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<14; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(offset[i]*w, 0.0) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(offset[i]*w, 0.0) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
+
+//py blurninja.py --expand 14 --reduce 14 57 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Enthusiast/BreathOfTheWild_5760p/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Enthusiast/BreathOfTheWild_5760p/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 5760
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.05842515, 0.11378184, 0.10229613, 0.08445599, 0.06401931, 0.04454418, 0.02843975, 0.01665463, 0.00894132, 0.00439816, 0.00198084, 0.00081621, 0.00030743, 0.00010575, 0.00003318, 0.00000949, 0.00000247, 0.00000058, 0.00000013, 0.00000002 );
+uniform float offset[] = float[]( 0.00000000, 1.49197861, 3.48128342, 5.47058824, 7.45989305, 9.44919786, 11.43850267, 13.42780749, 15.41711230, 17.40641711, 19.39572193, 21.38502674, 23.37433155, 25.36363636, 27.35294118, 29.34224599, 31.33155080, 33.32085561, 35.31016043, 37.29946524 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<20; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(0.0, offset[i]*h) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(0.0, offset[i]*h) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }

--- a/Enthusiast/BreathOfTheWild_5760p/6279271034da8f93_0000000000000079_ps.txt
+++ b/Enthusiast/BreathOfTheWild_5760p/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 10240
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.05842515, 0.11378184, 0.10229613, 0.08445599, 0.06401931, 0.04454418, 0.02843975, 0.01665463, 0.00894132, 0.00439816, 0.00198084, 0.00081621, 0.00030743, 0.00010575, 0.00003318, 0.00000949, 0.00000247, 0.00000058, 0.00000013, 0.00000002 );
+uniform float offset[] = float[]( 0.00000000, 1.49197861, 3.48128342, 5.47058824, 7.45989305, 9.44919786, 11.43850267, 13.42780749, 15.41711230, 17.40641711, 19.39572193, 21.38502674, 23.37433155, 25.36363636, 27.35294118, 29.34224599, 31.33155080, 33.32085561, 35.31016043, 37.29946524 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<20; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(offset[i]*w, 0.0) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(offset[i]*w, 0.0) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
+
+//py blurninja.py --expand 29 --reduce 29 129 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Quality/BreathOfTheWild_1080p/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1080p/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 1080
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.18571429, 0.28870130, 0.10363636, 0.01480519 );
+uniform float offset[] = float[]( 0.00000000, 1.42105263, 3.31578947, 5.21052632 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<4; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(0.0, offset[i]*h) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(0.0, offset[i]*h) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }

--- a/Quality/BreathOfTheWild_1080p/6279271034da8f93_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1080p/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 1920
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.18571429, 0.28870130, 0.10363636, 0.01480519 );
+uniform float offset[] = float[]( 0.00000000, 1.42105263, 3.31578947, 5.21052632 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<4; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(offset[i]*w, 0.0) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(offset[i]*w, 0.0) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
+
+//py blurninja.py --expand 3 --reduce 3 13 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Quality/BreathOfTheWild_1080pUW/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1080pUW/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 1080
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.18571429, 0.28870130, 0.10363636, 0.01480519 );
+uniform float offset[] = float[]( 0.00000000, 1.42105263, 3.31578947, 5.21052632 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<4; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(0.0, offset[i]*h) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(0.0, offset[i]*h) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }

--- a/Quality/BreathOfTheWild_1080pUW/6279271034da8f93_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1080pUW/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 2560
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.16122494, 0.26575540, 0.12180456, 0.02865990, 0.00316767 );
+uniform float offset[] = float[]( 0.00000000, 1.44000000, 3.36000000, 5.28000000, 7.20000000 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<5; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(offset[i]*w, 0.0) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(offset[i]*w, 0.0) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
+
+//py blurninja.py --expand 4 --reduce 4 17 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Quality/BreathOfTheWild_1440p/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1440p/12d8627fe9906695_0000000000000079_ps.txt
@@ -7,9 +7,6 @@ layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
 uniform vec2 uf_fragCoordScale;
 
-//ivec2 ires = textureSize(textureUnitPS0,0);
-//vec2 res = vec2( float(ires.x), float(ires.y) );
-
 float data = passParameterSem0.z - passParameterSem0.w;
 float h = data / 1.38461538 * uf_fragCoordScale.y;
 
@@ -37,5 +34,3 @@ for (int i=1; i<2; i++) {
 
 passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
-
-//py blurninja.py --expand 4 --reduce 4 17 --linear

--- a/Quality/BreathOfTheWild_1440p/6279271034da8f93_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1440p/6279271034da8f93_0000000000000079_ps.txt
@@ -7,9 +7,6 @@ layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
 uniform vec2 uf_fragCoordScale;
 
-//ivec2 ires = textureSize(textureUnitPS0,0);
-//vec2 res = vec2( float(ires.x), float(ires.y) );
-
 float data = passParameterSem0.z - passParameterSem0.w;
 float w = data / 1.38461538 * uf_fragCoordScale.x;
 
@@ -39,3 +36,4 @@ passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
 
 //py blurninja.py --expand 4 --reduce 4 17 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Quality/BreathOfTheWild_1440pUW/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1440pUW/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 1440
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.16122494, 0.26575540, 0.12180456, 0.02865990, 0.00316767 );
+uniform float offset[] = float[]( 0.00000000, 1.44000000, 3.36000000, 5.28000000, 7.20000000 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<5; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(0.0, offset[i]*h) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(0.0, offset[i]*h) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }

--- a/Quality/BreathOfTheWild_1440pUW/6279271034da8f93_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1440pUW/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 3440
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.12858845, 0.22686677, 0.13719611, 0.05487844, 0.01422774, 0.00231288, 0.00022383 );
+uniform float offset[] = float[]( 0.00000000, 1.46153846, 3.41025641, 5.35897436, 7.30769231, 9.25641026, 11.20512821 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<7; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(offset[i]*w, 0.0) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(offset[i]*w, 0.0) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
+
+//py blurninja.py --expand 7 --reduce 7 25 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Quality/BreathOfTheWild_1800p/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1800p/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 1800
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.13583460, 0.23632042, 0.13504024, 0.04857179, 0.01068579, 0.00136997, 0.00009448 );
+uniform float offset[] = float[]( 0.00000000, 1.45714286, 3.40000000, 5.34285714, 7.28571429, 9.22857143, 11.17142857 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<7; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(0.0, offset[i]*h) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(0.0, offset[i]*h) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }

--- a/Quality/BreathOfTheWild_1800p/6279271034da8f93_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_1800p/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 3200
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.13583460, 0.23632042, 0.13504024, 0.04857179, 0.01068579, 0.00136997, 0.00009448 );
+uniform float offset[] = float[]( 0.00000000, 1.45714286, 3.40000000, 5.34285714, 7.28571429, 9.22857143, 11.17142857 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<7; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(offset[i]*w, 0.0) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(offset[i]*w, 0.0) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
+
+//py blurninja.py --expand 5 --reduce 5 25 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Quality/BreathOfTheWild_2160pUW/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_2160pUW/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 2160
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.12537086, 0.22251971, 0.13786547, 0.05769140, 0.01602539, 0.00287352, 0.00031864, 0.00002045 );
+uniform float offset[] = float[]( 0.00000000, 1.46341463, 3.41463415, 5.36585366, 7.31707317, 9.26829268, 11.21951220, 13.17073171 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<8; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(0.0, offset[i]*h) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(0.0, offset[i]*h) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }

--- a/Quality/BreathOfTheWild_2160pUW/6279271034da8f93_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_2160pUW/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 5120
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
+uniform float weight[] = float[]( 0.11011604, 0.20071416, 0.13842356, 0.07060718, 0.02643049, 0.00717399, 0.00138786, 0.00018683, 0.00001693, 0.00000098 );
+uniform float offset[] = float[]( 0.00000000, 1.47169811, 3.43396226, 5.39622642, 7.35849057, 9.32075472, 11.28301887, 13.24528302, 15.20754717, 17.16981132 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R1f = texture( textureUnitPS0, R0f ) * weight[0];
+for (int i=1; i<10; i++) {
+	R1f += texture( textureUnitPS0, R0f + vec2(offset[i]*w, 0.0) ) * weight[i];
+	R1f += texture( textureUnitPS0, R0f - vec2(offset[i]*w, 0.0) ) * weight[i];
 	}
-	passPixelColor0 = R1f;
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	}
+
+passPixelColor0 = ( (uf_fragCoordScale.y == 1.0) ? R2f : R1f );
 }
+
+//py blurninja.py --expand 8 --reduce 8 37 --linear
+//game original --expand 2 --reduce 2 9 --linear

--- a/Quality/BreathOfTheWild_Switch/12d8627fe9906695_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_Switch/12d8627fe9906695_0000000000000079_ps.txt
@@ -1,27 +1,27 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 9fad3b3505a6d831
-// Used for: Vertical Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 12d8627fe9906695 // vertical bloom 1080
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float h = data / 1.38461538 * uf_fragCoordScale.y;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(0.0, offset[i]) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(0.0, offset[i]) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.x, passParameterSem0.w);
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(0.0, o_offset[i]*h) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(0.0, o_offset[i]*h) ) * o_weight[i];
 	}
-	passPixelColor0 = R1f;
+
+passPixelColor0 = R2f;
 }

--- a/Quality/BreathOfTheWild_Switch/6279271034da8f93_0000000000000079_ps.txt
+++ b/Quality/BreathOfTheWild_Switch/6279271034da8f93_0000000000000079_ps.txt
@@ -1,27 +1,30 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-// shader 0457fe3efc9a772f
-// Used for: Horizontal Blur
-const float blurFactor = 1.0; //Higher is less blur
-
-// Implementation of http://rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+// shader 6279271034da8f93 // horizontal bloom 1920
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4247000 res 96x96x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
 layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
 
-uniform float weight[] = float[](0.18571429, 0.28870130, 0.10363636, 0.01480519);
-uniform float offset[] = float[](0.00000000, 1.42105263, 3.31578947, 5.21052632);
+float data = passParameterSem0.z - passParameterSem0.w;
+float w = data / 1.38461538 * uf_fragCoordScale.x;
 
-ivec2 inputRes = textureSize(textureUnitPS0, 0);
-vec2 outputRes = vec2(float(inputRes.x), float(inputRes.y));
-vec2 scale = outputRes * blurFactor;
+uniform float o_weight[] = float[]( 0.29411765, 0.35294118 );
+uniform float o_offset[] = float[]( 0.00000000, 1.33333333 );
+
 void main()
 {
-	vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
-	vec4 R1f = texture(textureUnitPS0, R0f) * weight[0];
-	for (int i = 1; i<4; i++) {
-		R1f += texture(textureUnitPS0, R0f + (vec2(offset[i], 0.0) / scale)) * weight[i];
-		R1f += texture(textureUnitPS0, R0f - (vec2(offset[i], 0.0) / scale)) * weight[i];
+vec2 R0f = vec2(passParameterSem0.w, passParameterSem0.x);
+
+vec4 R2f = texture( textureUnitPS0, R0f ) * o_weight[0];
+for (int i=1; i<2; i++) {
+	R2f += texture( textureUnitPS0, R0f + vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
+	R2f += texture( textureUnitPS0, R0f - vec2(o_offset[i]*w, 0.0) ) * o_weight[i];
 	}
-	passPixelColor0 = R1f;
+
+passPixelColor0 = R2f;
 }
+
+
+//game original --expand 2 --reduce 2 9 --linear


### PR DESCRIPTION
The old way used in menu blur is kinda hacky (cuz later found the games's original blur is
linear sampled 5x5, not jump lines), and seems to have some negative effect when used on bloom (some objects' bloom has ghosting because the offsets are too large)
So back to increasing taps, however as the image size goes up, it becomes quite hard/impossible to get the same blurry result as 320x180 for some reason. 5x5 menu blur ends up with 100 taps in 10k to get the similar blur, and 9x9 used in bloom is even blurrier... so I gave up trying to get the same blur by increasing a lot of taps, but just scale linearly to fix pixelation first and wait for a better solution.
Also the texturesize() returns weird value when mipmap is present, so changed to calculate the image size from the values passed from vertex shader (as we already figured out what blur is used so offset is known).
![img](https://cdn.discordapp.com/attachments/292733452590120961/366299236481892362/image.png)