### PR TITLE
Fix explosion smoke by using the min shaders

### DIFF
--- a/Workaround/BreathOfTheWild_BombAsh/71b06814302a7aad_000000000001c24b_ps.txt
+++ b/Workaround/BreathOfTheWild_BombAsh/71b06814302a7aad_000000000001c24b_ps.txt
@@ -1,0 +1,382 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+// shader 71b06814302a7aad
+uniform ivec4 uf_remappedPS[6];
+uniform float uf_alphaTestRef;
+layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x21048800 res 256x128x1 dim 1 tm: 4 format 0007 compSel: 0 1 1 1 mipView: 0x0 (num 0x9) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 0 2 0 border: 0
+layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x2105e800 res 256x256x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x9) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 1 2 0 border: 0
+layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x21156000 res 128x128x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 0 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 0 0 0 border: 0
+layout(binding = 4) uniform sampler2D textureUnitPS4;// Tex4 addr 0xf4e91800 res 1280x720x1 dim 1 tm: 4 format 0806 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler4 ClampX/Y/Z: 2 2 0 border: 0
+layout(binding = 10) uniform samplerCubeArray textureUnitPS10;// Tex10 addr 0x3d568800 res 16x16x1 dim 3 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x2) sliceView: 0x0 (num 0x6) Sampler10 ClampX/Y/Z: 2 2 2 border: 1
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
+layout(location = 2) in vec4 passParameterSem3;
+layout(location = 3) in vec4 passParameterSem4;
+layout(location = 4) in vec4 passParameterSem8;
+layout(location = 5) in vec4 passParameterSem9;
+layout(location = 6) in vec4 passParameterSem11;
+layout(location = 7) in vec4 passParameterSem14;
+layout(location = 8) in vec4 passParameterSem15;
+layout(location = 9) in vec4 passParameterSem16;
+layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
+void redcCUBE(vec4 src0, vec4 src1, out vec3 stm, out int faceId)
+{
+// stm -> x .. s, y .. t, z .. MajorAxis*2.0
+vec3 inputCoord = normalize(vec3(src1.y, src1.x, src0.x));
+float rx = inputCoord.x;
+float ry = inputCoord.y;
+float rz = inputCoord.z;
+if( abs(rx) > abs(ry) && abs(rx) > abs(rz) )
+{
+stm.z = rx*2.0;
+stm.xy = vec2(ry,rz);	
+if( rx >= 0.0 )
+{
+faceId = 0;
+}
+else
+{
+faceId = 1;
+}
+}
+else if( abs(ry) > abs(rx) && abs(ry) > abs(rz) )
+{
+stm.z = ry*2.0;
+stm.xy = vec2(rx,rz);	
+if( ry >= 0.0 )
+{
+faceId = 2;
+}
+else
+{
+faceId = 3;
+}
+}
+else //if( abs(rz) > abs(ry) && abs(rz) > abs(rx) )
+{
+stm.z = rz*2.0;
+stm.xy = vec2(rx,ry);	
+if( rz >= 0.0 )
+{
+faceId = 4;
+}
+else
+{
+faceId = 5;
+}
+}
+}
+vec3 redcCUBEReverse(vec2 st, int faceId)
+{
+st.yx = st.xy;
+vec3 v;
+float majorAxis = 1.0;
+if( faceId == 0 )
+{
+v.yz = (st-vec2(1.5))*(majorAxis*2.0);
+v.x = 1.0;
+}
+else if( faceId == 1 )
+{
+v.yz = (st-vec2(1.5))*(majorAxis*2.0);
+v.x = -1.0;
+}
+else if( faceId == 2 )
+{
+v.xz = (st-vec2(1.5))*(majorAxis*2.0);
+v.y = 1.0;
+}
+else if( faceId == 3 )
+{
+v.xz = (st-vec2(1.5))*(majorAxis*2.0);
+v.y = -1.0;
+}
+else if( faceId == 4 )
+{
+v.xy = (st-vec2(1.5))*(majorAxis*2.0);
+v.z = 1.0;
+}
+else
+{
+v.xy = (st-vec2(1.5))*(majorAxis*2.0);
+v.z = -1.0;
+}
+return v;
+}
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ return min(a*b,min(abs(a)*3.40282347E+38F,abs(b)*3.40282347E+38F)); }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R3f = vec4(0.0);
+vec4 R4f = vec4(0.0);
+vec4 R5f = vec4(0.0);
+vec4 R6f = vec4(0.0);
+vec4 R7f = vec4(0.0);
+vec4 R8f = vec4(0.0);
+vec4 R9f = vec4(0.0);
+vec4 R10f = vec4(0.0);
+vec4 R11f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+vec4 R125f = vec4(0.0);
+vec4 R126f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+float cubeMapArrayIndex10 = 0.0;
+R0f = passParameterSem0;
+R1f = passParameterSem1;
+R2f = passParameterSem3;
+R3f = passParameterSem4;
+R4f = passParameterSem8;
+R5f = passParameterSem9;
+R6f = passParameterSem11;
+R7f = passParameterSem14;
+R8f = passParameterSem15;
+R9f = passParameterSem16;
+R10f.xw = (texture(textureUnitPS0, R4f.xy).xw);
+// 0
+PV0f.x = R3f.y * 1.5;
+R123f.y = (R10f.w * 2.0 + -(1.0));
+PV0f.y = R123f.y;
+R123f.z = (R10f.x * 2.0 + -(1.0));
+PV0f.z = R123f.z;
+PV0f.w = R3f.y;
+PV0f.w /= 2.0;
+R127f.w = 1.0 / R2f.w;
+PS0f = R127f.w;
+// 1
+PV1f.x = mul_nonIEEE(PV0f.z, PV0f.w);
+PV1f.y = mul_nonIEEE(PV0f.y, PV0f.w);
+PV1f.z = mul_nonIEEE(PV0f.y, PV0f.x);
+PV1f.w = mul_nonIEEE(PV0f.z, PV0f.x);
+R10f.x = mul_nonIEEE(R2f.x, PS0f);
+PS1f = R10f.x;
+// 2
+backupReg0f = R4f.z;
+backupReg1f = R4f.w;
+R4f.xyz = vec3(R5f.x,R5f.y,backupReg0f) + vec3(PV1f.w,PV1f.z,PV1f.x);
+R4f.w = backupReg1f + PV1f.y;
+R10f.y = mul_nonIEEE(R2f.y, R127f.w);
+PS0f = R10f.y;
+// 3
+backupReg0f = R6f.z;
+R5f.x = (R0f.w * 2.0 + -(1.0));
+PV1f.y = R2f.z * R127f.w;
+R6f.z = -(backupReg0f);
+PV1f.z = R6f.z;
+R2f.w = intBitsToFloat(uf_remappedPS[0].x);
+R5f.z = R1f.x + R1f.x;
+PS1f = R5f.z;
+// 4
+redcCUBE(vec4(PV1f.z,PV1f.z,R6f.x,R6f.y),vec4(R6f.y,R6f.x,PV1f.z,PV1f.z),cubeMapSTM,cubeMapFaceId);
+R127f.x = cubeMapSTM.x;
+R127f.y = cubeMapSTM.y;
+R127f.z = cubeMapSTM.z;
+R127f.w = intBitsToFloat(cubeMapFaceId);
+PV0f.x = R127f.x;
+PV0f.y = R127f.y;
+PV0f.z = R127f.z;
+PV0f.w = R127f.w;
+R126f.z = (mul_nonIEEE(intBitsToFloat(uf_remappedPS[1].w),PV1f.y) + -(intBitsToFloat(uf_remappedPS[1].y)));
+PS0f = R126f.z;
+// 5
+R6f.x = -(R1f.x) + R5f.z;
+R6f.y = R1f.y + R1f.y;
+PV1f.y = R6f.y;
+R2f.z = PV0f.w;
+R6f.w = R1f.z + R1f.z;
+PV1f.w = R6f.w;
+PS1f = 1.0 / abs(PV0f.z);
+// 6
+R123f.x = (mul_nonIEEE(R127f.y,PS1f) + 1.5);
+PV0f.x = R123f.x;
+R123f.y = (mul_nonIEEE(R127f.x,PS1f) + 1.5);
+PV0f.y = R123f.y;
+R3f.z = -(R1f.y) + PV1f.y;
+R5f.w = -(R1f.z) + PV1f.w;
+PS0f = 1.0 / R126f.z;
+// 7
+R2f.x = PV0f.x;
+R2f.y = PV0f.y;
+R6f.z = -(intBitsToFloat(uf_remappedPS[1].z)) * PS0f;
+R10f.w = -(R0f.w) + 1.0;
+R3f.w = -(R9f.w) + 1.0;
+PS1f = R3f.w;
+R4f.x = (texture(textureUnitPS2, R4f.xy).w);
+R10f.x = (texture(textureUnitPS4, R10f.xy).x);
+R11f.xyzw = (texture(textureUnitPS1, R4f.zw).xyzw);
+R2f.xyz = (textureLod(textureUnitPS10, vec4(redcCUBEReverse(R2f.xy,floatBitsToInt(R2f.z)),cubeMapArrayIndex10),R2f.w).xyz);
+// 0
+PV0f.x = R11f.z + R4f.x;
+PV0f.x /= 2.0;
+PV0f.y = -(R11f.z) + 1.0;
+R123f.z = (mul_nonIEEE(R10f.x,intBitsToFloat(uf_remappedPS[1].w)) + intBitsToFloat(uf_remappedPS[1].x));
+PV0f.z = R123f.z;
+R127f.w = R4f.x + R5f.x;
+PV0f.w = R127f.w;
+R127f.y = mul_nonIEEE(R10f.w, R10f.w);
+R127f.y *= 4.0;
+PS0f = R127f.y;
+// 1
+R123f.x = (-(PV0f.y) * intBitsToFloat(0x40c00000) + PV0f.z);
+PV1f.x = R123f.x;
+PV1f.y = mul_nonIEEE(R2f.x, R3f.w);
+PV1f.z = max(PV0f.w, intBitsToFloat(0x3e4ccccd));
+R125f.w = PV0f.x + intBitsToFloat(0xbecccccd);
+R125f.w *= 4.0;
+PS1f = mul_nonIEEE(R2f.y, R3f.w);
+// 2
+PV0f.x = mul_nonIEEE(R2f.z, R3f.w);
+PV0f.y = min(PV1f.z, intBitsToFloat(0x3e99999a));
+R2f.z = (mul_nonIEEE(PV1f.y,intBitsToFloat(uf_remappedPS[2].y)) + 0.0);
+R126f.w = PV1f.x + -(R6f.z);
+PV0f.w = R126f.w;
+R6f.z = (mul_nonIEEE(PS1f,intBitsToFloat(uf_remappedPS[2].y)) + 0.0);
+PS0f = R6f.z;
+// 3
+PV1f.x = PV0f.y + intBitsToFloat(0xbe4ccccd);
+R2f.y = (mul_nonIEEE(PV0f.x,intBitsToFloat(uf_remappedPS[2].y)) + 0.0);
+R123f.z = (PV0f.w * intBitsToFloat(0x3d08888a) + intBitsToFloat(0xbe2aaaad));
+R123f.z = clamp(R123f.z, 0.0, 1.0);
+PV1f.z = R123f.z;
+R3f.w = R7f.x + 0.0;
+R2f.x = R7f.y + 0.0;
+PS1f = R2f.x;
+// 4
+R7f.x = R7f.z + 0.0;
+PV0f.y = mul_nonIEEE(PV1f.z, PV1f.z);
+PV0f.z = mul_nonIEEE(R11f.w, R127f.w);
+PV0f.w = PV1f.x * intBitsToFloat(0x411fffff);
+R127f.w = R126f.w;
+R127f.w *= 2.0;
+R127f.w = clamp(R127f.w, 0.0, 1.0);
+PS0f = R127f.w;
+// 5
+R127f.x = (0.5 * PV0f.y + 0.5);
+R126f.y = (mul_nonIEEE(PV0f.w,R125f.w) + -(R127f.y));
+R126f.y = clamp(R126f.y, 0.0, 1.0);
+PV1f.z = mul_nonIEEE(R11f.x, PV0f.w);
+PV1f.w = mul_nonIEEE(R1f.w, PV0f.z);
+PV1f.w = clamp(PV1f.w, 0.0, 1.0);
+// 6
+R123f.x = (mul_nonIEEE(R5f.w,PV1f.z) + R1f.z);
+PV0f.x = R123f.x;
+R123f.y = (mul_nonIEEE(R3f.z,PV1f.z) + R1f.y);
+PV0f.y = R123f.y;
+R123f.z = (mul_nonIEEE(R6f.x,PV1f.z) + R1f.x);
+PV0f.z = R123f.z;
+PV0f.w = mul_nonIEEE(PV1f.w, R127f.w);
+PV0f.w = clamp(PV0f.w, 0.0, 1.0);
+// 7
+R123f.y = (mul_nonIEEE(R6f.w,R11f.y) + PV0f.x);
+PV1f.y = R123f.y;
+R123f.z = (mul_nonIEEE(R6f.y,R11f.y) + PV0f.y);
+PV1f.z = R123f.z;
+R123f.w = (mul_nonIEEE(R5f.z,R11f.y) + PV0f.z);
+PV1f.w = R123f.w;
+R5f.w = mul_nonIEEE(R3f.x, PV0f.w);
+PS1f = R5f.w;
+// 8
+R127f.y = mul_nonIEEE(PV1f.y, R127f.x);
+PV0f.y = R127f.y;
+R127f.z = mul_nonIEEE(PV1f.z, R127f.x);
+PV0f.z = R127f.z;
+R127f.w = mul_nonIEEE(PV1f.w, R127f.x);
+PV0f.w = R127f.w;
+// 9
+backupReg0f = R0f.y;
+PV1f.y = R0f.z + -(PV0f.y);
+PV1f.z = backupReg0f + -(PV0f.z);
+PV1f.w = R0f.x + -(PV0f.w);
+// 10
+backupReg0f = R127f.z;
+R127f.x = (mul_nonIEEE(PV1f.w,R126f.y) + R127f.w);
+PV0f.x = R127f.x;
+R127f.z = (mul_nonIEEE(PV1f.y,R126f.y) + R127f.y);
+PV0f.z = R127f.z;
+R127f.w = (mul_nonIEEE(PV1f.z,R126f.y) + backupReg0f);
+PV0f.w = R127f.w;
+// 11
+PV1f.x = max(PV0f.x, 0.0);
+PV1f.z = max(PV0f.z, 0.0);
+PV1f.w = max(PV0f.w, 0.0);
+// 12
+R0f.x = min(PV1f.w, intBitsToFloat(uf_remappedPS[3].y));
+PV0f.x = R0f.x;
+R0f.y = min(PV1f.x, intBitsToFloat(uf_remappedPS[3].y));
+PV0f.y = R0f.y;
+R0f.w = min(PV1f.z, intBitsToFloat(uf_remappedPS[3].y));
+PV0f.w = R0f.w;
+// 13
+R3f.x = R127f.z + -(PV0f.w);
+R3f.y = R127f.w + -(PV0f.x);
+R0f.z = R127f.x + -(PV0f.y);
+// 0
+R123f.y = (mul_nonIEEE(intBitsToFloat(uf_remappedPS[0].w),R2f.y) + R7f.x);
+PV0f.y = R123f.y;
+R123f.z = (mul_nonIEEE(intBitsToFloat(uf_remappedPS[0].w),R6f.z) + R2f.x);
+PV0f.z = R123f.z;
+R123f.w = (mul_nonIEEE(intBitsToFloat(uf_remappedPS[0].w),R2f.z) + R3f.w);
+PV0f.w = R123f.w;
+// 1
+R127f.x = (mul_nonIEEE(R0f.y,PV0f.w) + R0f.z);
+PV1f.x = R127f.x;
+R127f.z = (mul_nonIEEE(R0f.w,PV0f.y) + R3f.x);
+PV1f.z = R127f.z;
+R127f.w = (mul_nonIEEE(R0f.x,PV0f.z) + R3f.y);
+PV1f.w = R127f.w;
+// 2
+PV0f.x = -(PV1f.w) + intBitsToFloat(uf_remappedPS[4].y);
+PV0f.y = -(PV1f.x) + intBitsToFloat(uf_remappedPS[4].x);
+PV0f.w = -(PV1f.z) + intBitsToFloat(uf_remappedPS[4].z);
+// 3
+backupReg0f = R127f.x;
+R127f.x = (mul_nonIEEE(PV0f.w,R9f.y) + R127f.z);
+PV1f.x = R127f.x;
+R127f.y = (mul_nonIEEE(PV0f.x,R9f.y) + R127f.w);
+PV1f.y = R127f.y;
+R127f.z = (mul_nonIEEE(PV0f.y,R9f.y) + backupReg0f);
+PV1f.z = R127f.z;
+// 4
+PV0f.y = R8f.z + -(PV1f.x);
+PV0f.z = R8f.y + -(PV1f.y);
+PV0f.w = R8f.x + -(PV1f.z);
+// 5
+backupReg0f = R127f.x;
+R127f.x = (mul_nonIEEE(PV0f.w,R8f.w) + R127f.z);
+PV1f.x = R127f.x;
+R127f.z = (mul_nonIEEE(PV0f.y,R8f.w) + backupReg0f);
+PV1f.z = R127f.z;
+R127f.w = (mul_nonIEEE(PV0f.z,R8f.w) + R127f.y);
+PV1f.w = R127f.w;
+// 6
+PV0f.x = -(PV1f.w) + intBitsToFloat(uf_remappedPS[5].y);
+PV0f.y = -(PV1f.x) + intBitsToFloat(uf_remappedPS[5].x);
+PV0f.w = -(PV1f.z) + intBitsToFloat(uf_remappedPS[5].z);
+// 7
+R5f.x = (mul_nonIEEE(PV0f.y,R9f.x) + R127f.x);
+R5f.y = (mul_nonIEEE(PV0f.x,R9f.x) + R127f.w);
+R5f.z = (mul_nonIEEE(PV0f.w,R9f.x) + R127f.z);
+// export
+if( ((vec4(R5f.x, R5f.y, R5f.z, R5f.w)).a > uf_alphaTestRef) == false) discard;
+passPixelColor0 = vec4(R5f.x, R5f.y, R5f.z, R5f.w);
+}

--- a/Workaround/BreathOfTheWild_BombAsh/ea77e7f80b23e7b7_0000000000000000_vs.txt
+++ b/Workaround/BreathOfTheWild_BombAsh/ea77e7f80b23e7b7_0000000000000000_vs.txt
@@ -1,0 +1,2748 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_shading_language_packing : enable
+// shader ea77e7f80b23e7b7
+layout(binding = 6, std140) uniform uniformBlockVS6
+{
+vec4 uf_blockVS6[1024];
+};
+
+layout(binding = 7, std140) uniform uniformBlockVS7
+{
+vec4 uf_blockVS7[1024];
+};
+
+layout(binding = 8, std140) uniform uniformBlockVS8
+{
+vec4 uf_blockVS8[1024];
+};
+
+layout(binding = 11, std140) uniform uniformBlockVS11
+{
+vec4 uf_blockVS11[1024];
+};
+
+layout(binding = 13, std140) uniform uniformBlockVS13
+{
+vec4 uf_blockVS13[1024];
+};
+
+uniform vec2 uf_windowSpaceToClipSpaceTransform;
+uniform float uf_alphaTestRef;
+layout(binding = 40) uniform sampler2D textureUnitVS8;// Tex8 addr 0x3da26000 res 256x256x1 dim 1 tm: 4 format 0820 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler26 ClampX/Y/Z: 2 2 2 border: 1
+layout(binding = 45) uniform sampler2D textureUnitVS13;// Tex13 addr 0x3db8b000 res 12x1x1 dim 1 tm: 2 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler31 ClampX/Y/Z: 2 2 2 border: 1
+layout(location = 0) in uvec4 attrDataSem0;
+layout(location = 1) in uvec4 attrDataSem1;
+layout(location = 2) in uvec4 attrDataSem2;
+layout(location = 3) in uvec4 attrDataSem3;
+layout(location = 4) in uvec4 attrDataSem4;
+layout(location = 5) in uvec4 attrDataSem5;
+layout(location = 6) in uvec4 attrDataSem6;
+layout(location = 7) in uvec4 attrDataSem7;
+layout(location = 8) in uvec4 attrDataSem8;
+layout(location = 9) in uvec4 attrDataSem9;
+layout(location = 10) in uvec4 attrDataSem10;
+layout(location = 11) in uvec4 attrDataSem11;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 2) out vec4 passParameterSem3;
+layout(location = 4) out vec4 passParameterSem8;
+layout(location = 6) out vec4 passParameterSem11;
+layout(location = 7) out vec4 passParameterSem14;
+layout(location = 8) out vec4 passParameterSem15;
+layout(location = 9) out vec4 passParameterSem16;
+layout(location = 3) out vec4 passParameterSem4;
+layout(location = 5) out vec4 passParameterSem9;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ return min(a*b,min(abs(a)*3.40282347E+38F,abs(b)*3.40282347E+38F)); }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R7i = ivec4(0);
+ivec4 R8i = ivec4(0);
+ivec4 R9i = ivec4(0);
+ivec4 R10i = ivec4(0);
+ivec4 R11i = ivec4(0);
+ivec4 R12i = ivec4(0);
+ivec4 R13i = ivec4(0);
+ivec4 R14i = ivec4(0);
+ivec4 R15i = ivec4(0);
+ivec4 R16i = ivec4(0);
+ivec4 R17i = ivec4(0);
+ivec4 R18i = ivec4(0);
+ivec4 R19i = ivec4(0);
+ivec4 R20i = ivec4(0);
+ivec4 R21i = ivec4(0);
+ivec4 R22i = ivec4(0);
+ivec4 R23i = ivec4(0);
+ivec4 R24i = ivec4(0);
+ivec4 R25i = ivec4(0);
+ivec4 R26i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+bool activeMaskStack[4];
+bool activeMaskStackC[5];
+activeMaskStack[0] = false;
+activeMaskStack[1] = false;
+activeMaskStack[2] = false;
+activeMaskStackC[0] = false;
+activeMaskStackC[1] = false;
+activeMaskStackC[2] = false;
+activeMaskStackC[3] = false;
+activeMaskStack[0] = true;
+activeMaskStackC[0] = true;
+activeMaskStackC[1] = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder = attrDataSem6;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R7i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder.xyz = attrDataSem5.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R6i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), floatBitsToInt(1.0));
+attrDecoder = attrDataSem10;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R10i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem0;
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem1;
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem3;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R4i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem4;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R5i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem8;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R9i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem7;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R8i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem2;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R3i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+R10i.z = floatBitsToInt(-(intBitsToFloat(R10i.y)) + 1.0);
+R2i.w = 0;
+R3i.w = floatBitsToInt(1.0);
+PS0i = R3i.w;
+// 1
+R15i.w = floatBitsToInt(-(intBitsToFloat(R5i.w)) + uf_blockVS8[2].x);
+R10i.w = floatBitsToInt(-(intBitsToFloat(R10i.x)) + 1.0);
+PS1i = R10i.w;
+// 2
+predResult = (0.0 > intBitsToFloat(R15i.w));
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R21i.x = 0;
+R21i.y = 0;
+R21i.z = floatBitsToInt(uf_blockVS6[18].y * intBitsToFloat(0x40a00000));
+R22i.x = 0;
+PS0i = R22i.x;
+// 1
+R5i.w = R3i.w;
+}
+activeMaskStack[1] = activeMaskStack[1] == false;
+activeMaskStackC[2] = activeMaskStack[1] == true && activeMaskStackC[1] == true;
+if( activeMaskStackC[2] == true ) {
+// 0
+R5i.w = R2i.w;
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+predResult = (R5i.w == 0);
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+activeMaskStack[2] = activeMaskStack[1];
+activeMaskStackC[3] = activeMaskStackC[2];
+// 0
+PS0i = int(intBitsToFloat(R4i.w));
+// 1
+R4i.x = floatBitsToInt(float(PS0i));
+PS1i = R4i.x;
+// 2
+predResult = (intBitsToFloat(R15i.w) >= intBitsToFloat(R4i.x));
+activeMaskStack[2] = predResult;
+activeMaskStackC[3] = predResult == true && activeMaskStackC[2] == true;
+}
+else {
+activeMaskStack[2] = false;
+activeMaskStackC[3] = false;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R21i.x = 0;
+R21i.y = 0;
+R21i.z = floatBitsToInt(uf_blockVS6[18].y * intBitsToFloat(0x40a00000));
+R22i.x = 0;
+PS0i = R22i.x;
+// 1
+R2i.w = R3i.w;
+}
+activeMaskStackC[2] = activeMaskStack[1] == true && activeMaskStackC[1] == true;
+if( activeMaskStackC[2] == true ) {
+activeMaskStack[2] = activeMaskStack[1];
+activeMaskStackC[3] = activeMaskStackC[2];
+// 0
+predResult = (R2i.w == 0);
+activeMaskStack[2] = predResult;
+activeMaskStackC[3] = predResult == true && activeMaskStackC[2] == true;
+}
+else {
+activeMaskStack[2] = false;
+activeMaskStackC[3] = false;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(max(intBitsToFloat(R8i.x), 0.0));
+PV0i.y = floatBitsToInt((0.0 > uf_blockVS7[9].x)?1.0:0.0);
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.x), uf_blockVS7[10].y));
+PV0i.w = floatBitsToInt((uf_blockVS7[9].x > 0.0)?1.0:0.0);
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[9].x);
+// 1
+PV1i.x = floatBitsToInt(min(intBitsToFloat(PV0i.x), 0.0));
+PV1i.y = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(PS0i));
+R126i.z = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.y)));
+PV1i.z = R126i.z;
+R126i.w = floatBitsToInt(-(uf_blockVS7[96].x) + uf_blockVS7[97].x);
+R13i.x = floatBitsToInt(1.0 / intBitsToFloat(R4i.x));
+PS1i = R13i.x;
+// 2
+backupReg0i = R9i.x;
+R9i.x = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV1i.x));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 1.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(R127i.z) + intBitsToFloat(PV1i.y));
+R16i.w = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(PS1i));
+PV0i.w = R16i.w;
+R127i.z = floatBitsToInt(-(uf_blockVS7[96].y) + uf_blockVS7[97].y);
+PS0i = R127i.z;
+// 3
+R127i.x = floatBitsToInt(-(uf_blockVS7[96].z) + uf_blockVS7[97].z);
+PV1i.y = floatBitsToInt(fract(intBitsToFloat(PV0i.z)));
+PV1i.z = floatBitsToInt(-(uf_blockVS7[96].w) + uf_blockVS7[97].w);
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(PV0i.y)));
+// 4
+R125i.x = floatBitsToInt(-(uf_blockVS7[97].x) + uf_blockVS7[98].x);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.z), intBitsToFloat(PV1i.y)));
+R125i.w = floatBitsToInt(-(uf_blockVS7[97].y) + uf_blockVS7[98].y);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.z));
+// 5
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(intBitsToFloat(R127i.z) * intBitsToFloat(PS0i));
+R125i.y = floatBitsToInt(intBitsToFloat(R127i.w) + intBitsToFloat(PV0i.z));
+PV1i.y = R125i.y;
+R127i.z = floatBitsToInt(intBitsToFloat(R126i.w) * intBitsToFloat(PS0i));
+R127i.w = floatBitsToInt(intBitsToFloat(backupReg0i) * intBitsToFloat(PS0i));
+R126i.z = floatBitsToInt(-(uf_blockVS7[97].z) + uf_blockVS7[98].z);
+PS1i = R126i.z;
+// 6
+R126i.x = floatBitsToInt(intBitsToFloat(PV1i.y) + -(uf_blockVS7[96].w));
+PV0i.x = R126i.x;
+R127i.y = floatBitsToInt(intBitsToFloat(PV1i.y) + -(uf_blockVS7[97].w));
+// 7
+PV1i.x = floatBitsToInt(-(uf_blockVS7[97].w) + uf_blockVS7[98].w);
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(R127i.w)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(R127i.x)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), intBitsToFloat(R127i.z)));
+R127i.z = floatBitsToInt(intBitsToFloat(R125i.y) + -(uf_blockVS7[98].w));
+PS1i = R127i.z;
+// 8
+R124i.x = floatBitsToInt(uf_blockVS7[96].x + intBitsToFloat(PV1i.w));
+R0i.y = ((intBitsToFloat(R126i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+R124i.z = floatBitsToInt(uf_blockVS7[96].z + intBitsToFloat(PV1i.y));
+R127i.w = floatBitsToInt(uf_blockVS7[96].y + intBitsToFloat(PV1i.z));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+// 9
+backupReg0i = R125i.x;
+R125i.x = floatBitsToInt(-(uf_blockVS7[98].x) + uf_blockVS7[99].x);
+PV1i.y = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(PS0i));
+PV1i.z = floatBitsToInt(intBitsToFloat(R125i.w) * intBitsToFloat(PS0i));
+PV1i.w = floatBitsToInt(intBitsToFloat(backupReg0i) * intBitsToFloat(PS0i));
+R126i.x = floatBitsToInt(-(uf_blockVS7[98].y) + uf_blockVS7[99].y);
+PS1i = R126i.x;
+// 10
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV1i.w)));
+R126i.y = floatBitsToInt(-(uf_blockVS7[98].z) + uf_blockVS7[99].z);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV1i.z)));
+PS0i = floatBitsToInt(-(uf_blockVS7[98].w) + uf_blockVS7[99].w);
+// 11
+backupReg0i = R127i.y;
+R127i.x = floatBitsToInt(uf_blockVS7[97].y + intBitsToFloat(PV0i.w));
+R127i.y = floatBitsToInt(uf_blockVS7[97].x + intBitsToFloat(PV0i.x));
+R125i.z = ((intBitsToFloat(backupReg0i) >= 0.0)?(floatBitsToInt(1.0)):(0));
+R125i.w = floatBitsToInt(uf_blockVS7[97].z + intBitsToFloat(PV0i.z));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 12
+backupReg0i = R126i.y;
+PV0i.x = floatBitsToInt(intBitsToFloat(R125i.x) * intBitsToFloat(PS1i));
+R126i.y = ((intBitsToFloat(R127i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.y = R126i.y;
+PV0i.z = floatBitsToInt(intBitsToFloat(backupReg0i) * intBitsToFloat(PS1i));
+PV0i.w = floatBitsToInt(intBitsToFloat(R126i.x) * intBitsToFloat(PS1i));
+PS0i = floatBitsToInt(intBitsToFloat(R125i.y) + -(uf_blockVS7[99].w));
+// 13
+backupReg0i = R127i.z;
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PV0i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PV0i.x)));
+R127i.z = ((intBitsToFloat(PS0i) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R127i.z;
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV0i.z)));
+PS1i = floatBitsToInt(-(intBitsToFloat(PV0i.y)) + 1.0);
+// 14
+R126i.x = floatBitsToInt(uf_blockVS7[98].z + intBitsToFloat(PV1i.w));
+R125i.y = floatBitsToInt(uf_blockVS7[98].y + intBitsToFloat(PV1i.x));
+R126i.z = floatBitsToInt(uf_blockVS7[98].x + intBitsToFloat(PV1i.y));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 1.0);
+R124i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.z), intBitsToFloat(PS1i)));
+PS0i = R124i.y;
+// 15
+backupReg0i = R126i.y;
+R0i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[99].x, intBitsToFloat(R127i.z)));
+R126i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[99].y, intBitsToFloat(R127i.z)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV0i.w)));
+R124i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[99].z, intBitsToFloat(R127i.z)));
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PS0i)));
+PS1i = R125i.x;
+// 16
+backupReg0i = R126i.x;
+R126i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.y), intBitsToFloat(PV1i.z)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.z), intBitsToFloat(PV1i.z)));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(R124i.y)));
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV1i.z)));
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.w), intBitsToFloat(R124i.y)));
+PS0i = R127i.z;
+// 17
+PV1i.x = floatBitsToInt(-(intBitsToFloat(R0i.y)) + 1.0);
+PV1i.y = floatBitsToInt(-(intBitsToFloat(R125i.z)) + 1.0);
+PV1i.z = floatBitsToInt(intBitsToFloat(R8i.x) + intBitsToFloat(R8i.y));
+R4i.w = 0x3f800000;
+R127i.x = floatBitsToInt(intBitsToFloat(R8i.y) + intBitsToFloat(R8i.z));
+PS1i = R127i.x;
+// 18
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.y), intBitsToFloat(PV1i.y)));
+R125i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[96].z, intBitsToFloat(PV1i.x)));
+R125i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[96].y, intBitsToFloat(PV1i.x)));
+R125i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[96].x, intBitsToFloat(PV1i.x)));
+R124i.y = floatBitsToInt(intBitsToFloat(PV1i.z) * 0.5);
+PS0i = R124i.y;
+// 19
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(intBitsToFloat(backupReg0i) * 0.5);
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), intBitsToFloat(PV0i.x)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.x), intBitsToFloat(PV0i.x)));
+PS1i = floatBitsToInt(intBitsToFloat(R8i.x) + intBitsToFloat(R8i.z));
+// 20
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.w) + intBitsToFloat(R125i.w));
+PV0i.y = floatBitsToInt(intBitsToFloat(PS1i) * 0.5);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.y) + intBitsToFloat(R125i.y));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.z) + intBitsToFloat(R125i.z));
+R124i.x = floatBitsToInt(intBitsToFloat(R124i.y) + -(0.5));
+R124i.x = floatBitsToInt(intBitsToFloat(R124i.x) * 2.0);
+PS0i = R124i.x;
+// 21
+backupReg0i = R127i.z;
+PV1i.x = floatBitsToInt(intBitsToFloat(R126i.z) + intBitsToFloat(PV0i.w));
+PV1i.y = floatBitsToInt(intBitsToFloat(R125i.x) + intBitsToFloat(PV0i.x));
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.x) + -(0.5));
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.z) * 2.0);
+PV1i.w = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.z));
+R2i.w = floatBitsToInt(intBitsToFloat(PV0i.y) + -(0.5));
+R2i.w = floatBitsToInt(intBitsToFloat(R2i.w) * 2.0);
+PS1i = R2i.w;
+// 22
+PV0i.x = floatBitsToInt(intBitsToFloat(R126i.w) + intBitsToFloat(PV1i.w));
+PV0i.y = floatBitsToInt(intBitsToFloat(R126i.x) + intBitsToFloat(PV1i.x));
+PV0i.z = floatBitsToInt(intBitsToFloat(R127i.y) + intBitsToFloat(PV1i.y));
+R3i.w = floatBitsToInt(intBitsToFloat(R8i.x) + -(0.5));
+R4i.x = floatBitsToInt(intBitsToFloat(R8i.y) + -(0.5));
+PS0i = R4i.x;
+// 23
+R5i.x = floatBitsToInt(intBitsToFloat(R8i.z) + -(0.5));
+PV1i.y = floatBitsToInt(intBitsToFloat(R124i.w) + intBitsToFloat(PV0i.x));
+PV1i.z = floatBitsToInt(intBitsToFloat(R126i.y) + intBitsToFloat(PV0i.y));
+PV1i.w = floatBitsToInt(intBitsToFloat(R0i.x) + intBitsToFloat(PV0i.z));
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.x), uf_blockVS7[115].x));
+// 24
+backupReg0i = R9i.x;
+backupReg1i = R9i.z;
+backupReg2i = R9i.y;
+R9i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV1i.w)));
+R9i.y = floatBitsToInt(intBitsToFloat(PS1i) + uf_blockVS7[114].x);
+R9i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg1i), intBitsToFloat(PV1i.y)));
+R0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg2i), intBitsToFloat(PV1i.z)));
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), uf_blockVS7[115].y));
+PS0i = R0i.x;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R9i.z;
+backupReg1i = R0i.w;
+R4i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.x), uf_blockVS8[3].y));
+R9i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), uf_blockVS8[3].w));
+R0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg1i), uf_blockVS8[3].z));
+// 1
+R12i.x = floatBitsToInt(dot(vec4(intBitsToFloat(R2i.x),intBitsToFloat(R2i.y),intBitsToFloat(R2i.z),-0.0),vec4(uf_blockVS8[4].x,uf_blockVS8[4].y,uf_blockVS8[4].z,0.0)));
+PV1i.x = R12i.x;
+PV1i.y = R12i.x;
+PV1i.z = R12i.x;
+PV1i.w = R12i.x;
+PS1i = R8i.y;
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) * 2.0);
+// 2
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R2i.x),intBitsToFloat(R2i.y),intBitsToFloat(R2i.z),-0.0),vec4(uf_blockVS8[5].x,uf_blockVS8[5].y,uf_blockVS8[5].z,0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R5i.y = tempi.x;
+R124i.x = floatBitsToInt(floor(intBitsToFloat(PS1i)));
+PS0i = R124i.x;
+// 3
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R2i.x),intBitsToFloat(R2i.y),intBitsToFloat(R2i.z),-0.0),vec4(uf_blockVS8[6].x,uf_blockVS8[6].y,uf_blockVS8[6].z,0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R127i.z = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PS1i = R127i.z;
+// 4
+R2i.x = floatBitsToInt(uf_blockVS7[114].y + intBitsToFloat(R0i.x));
+PV0i.y = floatBitsToInt((0.0 > intBitsToFloat(R124i.x))?1.0:0.0);
+R11i.z = floatBitsToInt(intBitsToFloat(PV1i.x) + intBitsToFloat(0x358637bd));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.w), uf_blockVS7[115].z));
+PS0i = R8i.z;
+PS0i = floatBitsToInt(intBitsToFloat(PS0i) * 2.0);
+// 5
+R9i.x = floatBitsToInt(uf_blockVS7[114].z + intBitsToFloat(PV0i.w));
+R2i.y = floatBitsToInt(intBitsToFloat(R127i.z) + -(intBitsToFloat(PV0i.y)));
+R127i.z = floatBitsToInt(floor(intBitsToFloat(PS0i)));
+PV1i.z = R127i.z;
+// 6
+R14i.x = floatBitsToInt(dot(vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.y),intBitsToFloat(R1i.z),intBitsToFloat(R4i.w)),vec4(uf_blockVS8[4].x,uf_blockVS8[4].y,uf_blockVS8[4].z,uf_blockVS8[4].w)));
+PV0i.x = R14i.x;
+PV0i.y = R14i.x;
+PV0i.z = R14i.x;
+PV0i.w = R14i.x;
+R124i.w = floatBitsToInt((intBitsToFloat(PV1i.z) > 0.0)?1.0:0.0);
+PS0i = R124i.w;
+// 7
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.y),intBitsToFloat(R1i.z),intBitsToFloat(R4i.w)),vec4(uf_blockVS8[5].x,uf_blockVS8[5].y,uf_blockVS8[5].z,uf_blockVS8[5].w)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R11i.y = tempi.x;
+PS1i = floatBitsToInt((0.0 > intBitsToFloat(R127i.z))?1.0:0.0);
+// 8
+backupReg0i = R1i.z;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.y),intBitsToFloat(backupReg0i),intBitsToFloat(R4i.w)),vec4(uf_blockVS8[6].x,uf_blockVS8[6].y,uf_blockVS8[6].z,uf_blockVS8[6].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R1i.z = tempi.x;
+R0i.x = floatBitsToInt(intBitsToFloat(R124i.w) + -(intBitsToFloat(PS1i)));
+PS0i = R0i.x;
+// 9
+backupReg0i = R4i.x;
+R4i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), uf_blockVS7[113].x));
+R0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), uf_blockVS7[113].y));
+PV1i.z = R8i.x;
+PV1i.z = floatBitsToInt(intBitsToFloat(PV1i.z) * 2.0);
+// 10
+PV0i.w = floatBitsToInt(floor(intBitsToFloat(PV1i.z)));
+// 11
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PV0i.w))?1.0:0.0);
+PV1i.y = floatBitsToInt((intBitsToFloat(PV0i.w) > 0.0)?1.0:0.0);
+// 12
+R2i.z = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(PV1i.x)));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(uf_blockVS7[5].x) & 0x00010000;
+R127i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00020000;
+R124i.w = floatBitsToInt(uf_blockVS7[5].x) & 0x00040000;
+// 1
+PS1i = floatBitsToInt(float(PV0i.x));
+// 2
+PV0i.y = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), uf_blockVS7[113].z));
+PV0i.w = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PS0i = floatBitsToInt(float(R127i.z));
+// 3
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.y)));
+PV1i.y = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PV1i.z = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PS1i = floatBitsToInt(float(R124i.w));
+// 4
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.y = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(PV1i.z)));
+R127i.z = int(intBitsToFloat(PV1i.x));
+PS0i = R127i.z;
+// 5
+PV1i.x = 0 - PS0i;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.y)));
+R124i.w = int(intBitsToFloat(PV0i.z));
+PS1i = R124i.w;
+// 6
+PV0i.x = 0 - PS1i;
+PV0i.y = max(R127i.z, PV1i.x);
+R126i.w = ((uf_blockVS7[114].w == 1.0)?int(0xFFFFFFFF):int(0x0));
+R126i.y = int(intBitsToFloat(PV1i.w));
+PS0i = R126i.y;
+// 7
+PV1i.x = max(R124i.w, PV0i.x);
+PV1i.y = 0 - PS0i;
+PS1i = floatBitsToInt(float(PV0i.y));
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) * 2.0);
+// 8
+R124i.x = floatBitsToInt(-(uf_blockVS7[114].w) + 1.0);
+PV0i.z = max(R126i.y, PV1i.y);
+PV0i.w = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(PS1i)), intBitsToFloat(R2i.y)));
+PS0i = floatBitsToInt(float(PV1i.x));
+PS0i = floatBitsToInt(intBitsToFloat(PS0i) * 2.0);
+// 9
+backupReg0i = R0i.x;
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.y), intBitsToFloat(PV0i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(PS0i)), intBitsToFloat(backupReg0i)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.x), intBitsToFloat(PV0i.w)));
+PS1i = floatBitsToInt(float(PV0i.z));
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) * 2.0);
+// 10
+R126i.x = floatBitsToInt(intBitsToFloat(R9i.y) + intBitsToFloat(PV1i.x));
+PV0i.y = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(PS1i)), intBitsToFloat(R2i.z)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R3i.x) + intBitsToFloat(PV1i.z));
+PS0i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.y), intBitsToFloat(PV1i.y)));
+// 11
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.x), intBitsToFloat(PV0i.y)));
+PV1i.y = floatBitsToInt(intBitsToFloat(R3i.y) + intBitsToFloat(PS0i));
+R127i.z = floatBitsToInt(intBitsToFloat(R2i.x) + intBitsToFloat(PV0i.z));
+R125i.w = floatBitsToInt(intBitsToFloat(PV0i.w) + intBitsToFloat(R4i.x));
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), intBitsToFloat(PV0i.y)));
+// 12
+PV0i.x = floatBitsToInt(intBitsToFloat(R3i.z) + intBitsToFloat(PS1i));
+R126i.y = floatBitsToInt(intBitsToFloat(PV1i.y) + intBitsToFloat(R0i.y));
+R124i.w = floatBitsToInt(intBitsToFloat(R9i.x) + intBitsToFloat(PV1i.x));
+tempResultf = log2(uf_blockVS7[114].w);
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS0i = floatBitsToInt(tempResultf);
+// 13
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R15i.w), intBitsToFloat(PS0i)));
+R127i.w = floatBitsToInt(intBitsToFloat(PV0i.x) + intBitsToFloat(R126i.z));
+R126i.z = floatBitsToInt(1.0 / intBitsToFloat(R124i.x));
+PS1i = R126i.z;
+// 14
+PS0i = floatBitsToInt(exp2(intBitsToFloat(PV1i.x)));
+// 15
+PV1i.y = floatBitsToInt(-(intBitsToFloat(PS0i)) + 1.0);
+// 16
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.y) * intBitsToFloat(R126i.z));
+// 17
+R123i.y = ((R126i.w == 0)?(PV0i.w):(R15i.w));
+PV1i.y = R123i.y;
+// 18
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.x), intBitsToFloat(PV1i.y)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.w), intBitsToFloat(PV1i.y)));
+// 19
+PV1i.x = floatBitsToInt(intBitsToFloat(R126i.y) + intBitsToFloat(PV0i.z));
+PV1i.y = floatBitsToInt(intBitsToFloat(R125i.w) + intBitsToFloat(PV0i.x));
+PV1i.z = floatBitsToInt(intBitsToFloat(R127i.w) + intBitsToFloat(PV0i.w));
+// 20
+R123i.x = floatBitsToInt((intBitsToFloat(PV1i.x) * intBitsToFloat(0x3e22f983) + 0.5));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0x3e22f983) + 0.5));
+PV0i.y = R123i.y;
+PV0i.z = floatBitsToInt(uf_blockVS7[13].x);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) / 2.0);
+R123i.w = floatBitsToInt((intBitsToFloat(PV1i.y) * intBitsToFloat(0x3e22f983) + 0.5));
+PV0i.w = R123i.w;
+// 21
+PV1i.x = floatBitsToInt(fract(intBitsToFloat(PV0i.w)));
+R0i.y = floatBitsToInt(intBitsToFloat(R7i.x) + intBitsToFloat(PV0i.z));
+PV1i.z = floatBitsToInt(fract(intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt(fract(intBitsToFloat(PV0i.y)));
+PS1i = floatBitsToInt(uf_blockVS7[13].y);
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) / 2.0);
+// 22
+R3i.x = floatBitsToInt(intBitsToFloat(R7i.y) + intBitsToFloat(PS1i));
+R123i.y = floatBitsToInt((intBitsToFloat(PV1i.x) * intBitsToFloat(0x40c90fdb) + intBitsToFloat(0xc0490fdb)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((intBitsToFloat(PV1i.w) * intBitsToFloat(0x40c90fdb) + intBitsToFloat(0xc0490fdb)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0x40c90fdb) + intBitsToFloat(0xc0490fdb)));
+PV0i.w = R123i.w;
+// 23
+R126i.x = floatBitsToInt(intBitsToFloat(PV0i.z) * intBitsToFloat(0x3e22f983));
+R126i.y = floatBitsToInt(intBitsToFloat(PV0i.w) * intBitsToFloat(0x3e22f983));
+R127i.z = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(0x3e22f983));
+PV1i.z = R127i.z;
+// 24
+R125i.w = floatBitsToInt(sin((intBitsToFloat(PV1i.z))/0.1591549367));
+PS0i = R125i.w;
+// 25
+R127i.y = floatBitsToInt(cos((intBitsToFloat(R127i.z))/0.1591549367));
+PS1i = R127i.y;
+// 26
+R124i.x = floatBitsToInt(sin((intBitsToFloat(R126i.y))/0.1591549367));
+PS0i = R124i.x;
+// 27
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.w), intBitsToFloat(PS0i)));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PS0i)));
+R127i.z = floatBitsToInt(cos((intBitsToFloat(R126i.y))/0.1591549367));
+PS1i = R127i.z;
+// 28
+R125i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PS1i)));
+PV0i.y = R125i.y;
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.w), intBitsToFloat(PS1i)));
+PV0i.w = R127i.w;
+R3i.w = floatBitsToInt(sin((intBitsToFloat(R126i.x))/0.1591549367));
+PS0i = R3i.w;
+// 29
+R9i.x = floatBitsToInt(-(intBitsToFloat(PS0i)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PS0i), intBitsToFloat(PV0i.w)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PS0i), intBitsToFloat(PV0i.y)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PS0i), intBitsToFloat(R126i.z)));
+R126i.y = floatBitsToInt(cos((intBitsToFloat(R126i.x))/0.1591549367));
+PS1i = R126i.y;
+// 30
+R4i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PS1i)));
+R9i.y = floatBitsToInt(intBitsToFloat(R127i.x) + intBitsToFloat(PV1i.z));
+R3i.z = floatBitsToInt(-(intBitsToFloat(R126i.z)) + intBitsToFloat(PV1i.y));
+R2i.w = floatBitsToInt(-(intBitsToFloat(R127i.w)) + intBitsToFloat(PV1i.w));
+R4i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PS1i)));
+PS0i = R4i.w;
+// 31
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.x), intBitsToFloat(R126i.y)));
+R3i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.w), intBitsToFloat(R126i.y)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(R127i.x)));
+// 32
+R2i.x = floatBitsToInt(intBitsToFloat(R125i.y) + intBitsToFloat(PV1i.z));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R127i.x = floatBitsToInt(intBitsToFloat(R14i.x) + -(uf_blockVS6[17].x));
+PV0i.x = R127i.x;
+R125i.y = floatBitsToInt(intBitsToFloat(R11i.y) + -(uf_blockVS6[17].y));
+PV0i.y = R125i.y;
+R127i.z = floatBitsToInt(intBitsToFloat(R1i.z) + -(uf_blockVS6[17].z));
+PV0i.z = R127i.z;
+R125i.w = floatBitsToInt(-(intBitsToFloat(R14i.x)) + uf_blockVS6[17].x);
+R126i.y = floatBitsToInt(-(intBitsToFloat(R11i.y)) + uf_blockVS6[17].y);
+PS0i = R126i.y;
+// 1
+tempi.x = floatBitsToInt(dot(vec4(-(intBitsToFloat(PV0i.x)),-(intBitsToFloat(PV0i.y)),-(intBitsToFloat(PV0i.z)),-0.0),vec4(-(intBitsToFloat(PV0i.x)),-(intBitsToFloat(PV0i.y)),-(intBitsToFloat(PV0i.z)),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R125i.z = floatBitsToInt(-(intBitsToFloat(R1i.z)) + uf_blockVS6[17].z);
+PS1i = R125i.z;
+// 2
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R127i.x),intBitsToFloat(R125i.y),intBitsToFloat(R127i.z),-0.0),vec4(intBitsToFloat(R127i.x),intBitsToFloat(R125i.y),intBitsToFloat(R127i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+PS0i = floatBitsToInt(tempResultf);
+// 3
+PV1i.x = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R125i.y)), intBitsToFloat(PS0i)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R127i.x)), intBitsToFloat(PS0i)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R127i.z)), intBitsToFloat(PS0i)));
+PS1i = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+// 4
+R1i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[13].z, intBitsToFloat(PV1i.y)));
+PV0i.x = R1i.x;
+R1i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[13].z, intBitsToFloat(PV1i.x)));
+PV0i.y = R1i.y;
+R12i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[13].z, intBitsToFloat(PV1i.w)));
+PV0i.z = R12i.z;
+R126i.z = floatBitsToInt(1.0 / intBitsToFloat(PS1i));
+PS0i = R126i.z;
+// 5
+PV1i.x = floatBitsToInt(intBitsToFloat(R127i.x) + intBitsToFloat(PV0i.x));
+PV1i.y = floatBitsToInt(intBitsToFloat(R125i.y) + intBitsToFloat(PV0i.y));
+PV1i.z = floatBitsToInt(intBitsToFloat(R127i.z) + intBitsToFloat(PV0i.z));
+// 6
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),-0.0),vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+// 7
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R125i.w),intBitsToFloat(R126i.y),intBitsToFloat(R125i.z),-0.0),vec4(intBitsToFloat(R125i.w),intBitsToFloat(R126i.y),intBitsToFloat(R125i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+PS1i = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+// 8
+R9i.w = floatBitsToInt(intBitsToFloat(PS1i) * intBitsToFloat(R126i.z));
+PV0i.w = R9i.w;
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+R127i.w = floatBitsToInt(tempResultf);
+PS0i = R127i.w;
+// 9
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.z), intBitsToFloat(PV0i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.w), intBitsToFloat(PV0i.w)));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.w), intBitsToFloat(PS0i)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R4i.y), intBitsToFloat(PV0i.w)));
+R125i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PS0i)));
+PS1i = R125i.y;
+// 10
+R124i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.z), intBitsToFloat(R127i.w)));
+PV0i.x = R124i.x;
+R124i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.z), intBitsToFloat(PV1i.x)));
+R9i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), intBitsToFloat(R0i.y)));
+R0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), intBitsToFloat(R3i.x)));
+PS0i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PS1i), -(uf_blockVS6[1].z)));
+// 11
+R127i.x = floatBitsToInt((mul_nonIEEE(uf_blockVS6[1].y,intBitsToFloat(PV0i.x)) + intBitsToFloat(PS0i)));
+R4i.y = R126i.z;
+PV1i.y = R4i.y;
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.x), -(uf_blockVS6[1].x)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.z), -(uf_blockVS6[1].y)));
+R2i.z = R125i.y;
+PS1i = R2i.z;
+// 12
+R11i.x = R124i.x;
+PV0i.x = R11i.x;
+R126i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS6[1].z,intBitsToFloat(R126i.z)) + intBitsToFloat(PV1i.z)));
+PV0i.y = R126i.y;
+R125i.z = floatBitsToInt((mul_nonIEEE(uf_blockVS6[1].x,intBitsToFloat(R125i.y)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R125i.z;
+R127i.w = PV1i.y;
+R126i.x = PS1i;
+PS0i = R126i.x;
+// 13
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R127i.x),intBitsToFloat(PV0i.y),intBitsToFloat(PV0i.z),-0.0),vec4(intBitsToFloat(R127i.x),intBitsToFloat(PV0i.y),intBitsToFloat(PV0i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R125i.w = PV0i.x;
+PS1i = R125i.w;
+// 14
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), intBitsToFloat(PS1i)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), intBitsToFloat(R126i.x)));
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), intBitsToFloat(R127i.w)));
+R124i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.y), intBitsToFloat(R127i.w)));
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+PS0i = floatBitsToInt(tempResultf);
+// 15
+backupReg0i = R126i.y;
+backupReg1i = R125i.z;
+R3i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS0i)));
+PV1i.x = R3i.x;
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PS0i)));
+PV1i.y = R126i.y;
+R125i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.y), intBitsToFloat(R126i.x)));
+R5i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg1i), intBitsToFloat(PS0i)));
+PV1i.w = R5i.w;
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.y), intBitsToFloat(R125i.w)));
+PS1i = R126i.w;
+// 16
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.z), intBitsToFloat(PV1i.y)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.y), intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.x), intBitsToFloat(PV1i.x)));
+R6i.w = PV1i.y;
+R5i.x = PV1i.w;
+PS0i = R5i.x;
+// 17
+R123i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R126i.y)),intBitsToFloat(R124i.x)) + intBitsToFloat(PV0i.y)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.w)),intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.z)));
+PV1i.y = R123i.y;
+R124i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R127i.w)));
+R123i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.x)),intBitsToFloat(R125i.y)) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+R7i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R125i.w)));
+PS1i = R7i.z;
+// 18
+backupReg0i = R0i.x;
+R7i.x = PV1i.y;
+PV0i.x = R7i.x;
+R7i.y = PV1i.x;
+PV0i.y = R7i.y;
+R0i.z = PV1i.w;
+PV0i.z = R0i.z;
+R125i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R126i.x)));
+PS0i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(R124i.y)));
+// 19
+R126i.x = PV0i.y;
+PV1i.x = R126i.x;
+R125i.y = PV0i.z;
+PV1i.y = R125i.y;
+R126i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.w),intBitsToFloat(R9i.x)) + intBitsToFloat(PS0i)));
+R127i.w = PV0i.x;
+PV1i.w = R127i.w;
+R0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.w), intBitsToFloat(R124i.y)));
+PS1i = R0i.y;
+// 20
+backupReg0i = R125i.x;
+R125i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.w),intBitsToFloat(PV1i.x)) + intBitsToFloat(R124i.w)));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.y),intBitsToFloat(PV1i.y)) + intBitsToFloat(backupReg0i)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.y),intBitsToFloat(PV1i.w)) + intBitsToFloat(R127i.y)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.y),intBitsToFloat(PV1i.x)) + intBitsToFloat(R127i.z)));
+PV0i.w = R123i.w;
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.w),intBitsToFloat(PV1i.w)) + intBitsToFloat(R125i.z)));
+PS0i = R127i.y;
+// 21
+R9i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.x),intBitsToFloat(R3i.x)) + intBitsToFloat(PV0i.w)));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.w),intBitsToFloat(R125i.y)) + intBitsToFloat(R126i.w)));
+PV1i.y = R123i.y;
+R5i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.x),intBitsToFloat(R5i.w)) + intBitsToFloat(PV0i.y)));
+R7i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R4i.x),intBitsToFloat(R126i.y)) + intBitsToFloat(PV0i.z)));
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R124i.y)));
+// 22
+backupReg0i = R3i.w;
+backupReg1i = R4i.x;
+R2i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(R5i.w)) + intBitsToFloat(PV1i.y)));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.w),intBitsToFloat(R3i.y)) + intBitsToFloat(PS1i)));
+PV0i.y = R123i.y;
+R4i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(R126i.y)) + intBitsToFloat(R127i.y)));
+R3i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(R3i.x)) + intBitsToFloat(R125i.x)));
+R4i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.z),intBitsToFloat(backupReg1i)) + intBitsToFloat(R126i.z)));
+PS0i = R4i.x;
+// 23
+backupReg0i = R3i.z;
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.w),intBitsToFloat(R127i.w)) + intBitsToFloat(R125i.w)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.w),intBitsToFloat(R126i.x)) + intBitsToFloat(R124i.z)));
+PV1i.y = R123i.y;
+R3i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.z),intBitsToFloat(backupReg0i)) + intBitsToFloat(PV0i.y)));
+// 24
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.w),intBitsToFloat(R4i.w)) + intBitsToFloat(R0i.y)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.x),intBitsToFloat(R126i.y)) + intBitsToFloat(PV1i.x)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.x),intBitsToFloat(R3i.x)) + intBitsToFloat(PV1i.y)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.w),intBitsToFloat(R125i.y)) + intBitsToFloat(R7i.z)));
+PV0i.w = R123i.w;
+// 25
+backupReg0i = R0i.x;
+backupReg1i = R9i.y;
+R0i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(R5i.w)) + intBitsToFloat(PV0i.w)));
+R9i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.z),intBitsToFloat(backupReg1i)) + intBitsToFloat(PV0i.x)));
+R9i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.z), intBitsToFloat(PV0i.y)));
+R5i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.z), intBitsToFloat(PV0i.z)));
+}
+if( activeMaskStackC[3] == true ) {
+activeMaskStack[3] = activeMaskStack[2];
+activeMaskStackC[4] = activeMaskStackC[3];
+// 0
+R126i.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R7i.y),intBitsToFloat(R4i.y),-0.0),vec4(intBitsToFloat(R4i.x),intBitsToFloat(R9i.y),intBitsToFloat(R3i.z),0.0)));
+PV0i.x = R126i.x;
+PV0i.y = R126i.x;
+PV0i.z = R126i.x;
+PV0i.w = R126i.x;
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.z), intBitsToFloat(R0i.x)));
+PS0i = R126i.y;
+// 1
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R6i.w),intBitsToFloat(R7i.x),intBitsToFloat(R2i.z),-0.0),vec4(intBitsToFloat(R4i.x),intBitsToFloat(R9i.y),intBitsToFloat(R3i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R127i.w = tempi.x;
+R125i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R3i.w)) + intBitsToFloat(R5i.w)));
+PS1i = R125i.x;
+// 2
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R5i.x),intBitsToFloat(R0i.z),intBitsToFloat(R11i.x),-0.0),vec4(intBitsToFloat(R4i.x),intBitsToFloat(R9i.y),intBitsToFloat(R3i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+// 3
+R0i.x = floatBitsToInt(intBitsToFloat(R14i.x) + intBitsToFloat(R126i.x));
+R0i.y = floatBitsToInt(intBitsToFloat(R11i.y) + intBitsToFloat(R127i.w));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R2i.x)) + intBitsToFloat(R126i.y)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.y),intBitsToFloat(R4i.z)) + intBitsToFloat(R9i.z)));
+PV1i.w = R123i.w;
+R0i.z = floatBitsToInt(intBitsToFloat(R1i.z) + intBitsToFloat(PV0i.x));
+PS1i = R0i.z;
+// 4
+R18i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.x),intBitsToFloat(R9i.x)) + intBitsToFloat(R125i.x)));
+R15i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.x),intBitsToFloat(R7i.w)) + intBitsToFloat(PV1i.w)));
+R14i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.x),intBitsToFloat(R5i.z)) + intBitsToFloat(PV1i.z)));
+// 5
+R2i.xyz = floatBitsToInt(vec3(-(intBitsToFloat(R14i.x)),-(intBitsToFloat(R11i.y)),-(intBitsToFloat(R1i.z))) + vec3(intBitsToFloat(R0i.x),intBitsToFloat(R0i.y),intBitsToFloat(R0i.z)));
+PV1i.x = R2i.x;
+PV1i.y = R2i.y;
+PV1i.z = R2i.z;
+// 6
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),-0.0),vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+// 7
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R12i.x),intBitsToFloat(R5i.y),intBitsToFloat(R11i.z),-0.0),vec4(intBitsToFloat(R12i.x),intBitsToFloat(R5i.y),intBitsToFloat(R11i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+PS1i = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+// 8
+R124i.z = ((intBitsToFloat(PS1i) > 0.0)?int(0xFFFFFFFF):int(0x0));
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+PS0i = floatBitsToInt(tempResultf);
+// 9
+R3i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.x), intBitsToFloat(PS0i)));
+R3i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.y), intBitsToFloat(PS0i)));
+R3i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.z), intBitsToFloat(PS0i)));
+// 10
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R12i.x),intBitsToFloat(R5i.y),intBitsToFloat(R11i.z),-0.0),vec4(intBitsToFloat(R12i.x),intBitsToFloat(R5i.y),intBitsToFloat(R11i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+// 11
+PS1i = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+// 12
+PV0i.x = ((intBitsToFloat(PS1i) > 0.0)?int(0xFFFFFFFF):int(0x0));
+// 13
+R4i.z = ((R124i.z == 0)?(0):(PV0i.x));
+// 14
+predResult = (R4i.z != 0);
+activeMaskStack[3] = predResult;
+activeMaskStackC[4] = predResult == true && activeMaskStackC[3] == true;
+}
+else {
+activeMaskStack[3] = false;
+activeMaskStackC[4] = false;
+}
+if( activeMaskStackC[4] == true ) {
+// 0
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R2i.x),intBitsToFloat(R2i.y),intBitsToFloat(R2i.z),-0.0),vec4(intBitsToFloat(R2i.x),intBitsToFloat(R2i.y),intBitsToFloat(R2i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.x), uf_blockVS7[95].x));
+PS0i = R127i.x;
+// 1
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.z), uf_blockVS7[95].x));
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.y), uf_blockVS7[95].x));
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV0i.x));
+PS1i = floatBitsToInt(tempResultf);
+// 2
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(PS1i)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(PS1i)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.z), intBitsToFloat(PS1i)));
+// 3
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R3i.y),intBitsToFloat(R3i.z),-0.0),vec4(intBitsToFloat(PV0i.x),intBitsToFloat(PV0i.y),intBitsToFloat(PV0i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(R127i.w)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(R127i.x)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(R127i.z)));
+// 5
+backupReg0i = R0i.x;
+backupReg1i = R0i.y;
+backupReg2i = R0i.z;
+R0i.xyz = floatBitsToInt(vec3(intBitsToFloat(backupReg0i),intBitsToFloat(backupReg1i),intBitsToFloat(backupReg2i)) + vec3(intBitsToFloat(PV0i.y),intBitsToFloat(PV0i.x),intBitsToFloat(PV0i.w)));
+}
+activeMaskStackC[3] = activeMaskStack[2] == true && activeMaskStackC[2] == true;
+if( activeMaskStackC[3] == true ) {
+// 0
+R2i.x = floatBitsToInt(intBitsToFloat(R14i.x) + intBitsToFloat(R1i.x));
+PV0i.x = R2i.x;
+R9i.y = floatBitsToInt(intBitsToFloat(R11i.y) + intBitsToFloat(R1i.y));
+PV0i.y = R9i.y;
+R2i.z = floatBitsToInt(intBitsToFloat(R1i.z) + intBitsToFloat(R12i.z));
+PV0i.z = R2i.z;
+R127i.w = floatBitsToInt(intBitsToFloat(R1i.x) + intBitsToFloat(R0i.x));
+R126i.w = floatBitsToInt(intBitsToFloat(R1i.y) + intBitsToFloat(R0i.y));
+PS0i = R126i.w;
+// 1
+PV1i.x = floatBitsToInt(-(uf_blockVS6[17].x) + intBitsToFloat(PV0i.x));
+PV1i.y = floatBitsToInt(-(uf_blockVS6[17].y) + intBitsToFloat(PV0i.y));
+R127i.z = floatBitsToInt(intBitsToFloat(R12i.z) + intBitsToFloat(R0i.z));
+R3i.w = 0x3f800000;
+PS1i = floatBitsToInt(-(uf_blockVS6[17].z) + intBitsToFloat(PV0i.z));
+// 2
+backupReg0i = R127i.w;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PS1i),-0.0),vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PS1i),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R127i.w = floatBitsToInt(-(intBitsToFloat(R2i.x)) + intBitsToFloat(backupReg0i));
+PS0i = R127i.w;
+// 3
+R127i.x = floatBitsToInt((uf_blockVS7[8].x > 0.0)?1.0:0.0);
+R127i.y = floatBitsToInt(-(intBitsToFloat(R2i.z)) + intBitsToFloat(R127i.z));
+R127i.z = floatBitsToInt(-(intBitsToFloat(R9i.y)) + intBitsToFloat(R126i.w));
+R126i.w = 0x3f800000;
+PV1i.w = R126i.w;
+R0i.x = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+PS1i = R0i.x;
+// 4
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R2i.x),intBitsToFloat(R9i.y),intBitsToFloat(R2i.z),intBitsToFloat(PV1i.w)),vec4(uf_blockVS6[10].x,uf_blockVS6[10].y,uf_blockVS6[10].z,uf_blockVS6[10].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R125i.w = tempi.x;
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(R9i.w));
+// 5
+PV1i.x = floatBitsToInt((0.0 > uf_blockVS7[8].x)?1.0:0.0);
+R0i.y = floatBitsToInt(intBitsToFloat(R127i.y) * intBitsToFloat(PS0i));
+R0i.z = floatBitsToInt(intBitsToFloat(R127i.z) * intBitsToFloat(PS0i));
+R0i.w = floatBitsToInt(intBitsToFloat(R127i.w) * intBitsToFloat(PS0i));
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[8].x);
+// 6
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(PS1i));
+R127i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + -(intBitsToFloat(PV1i.x)));
+PV0i.z = R127i.z;
+// 7
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R2i.x),intBitsToFloat(R9i.y),intBitsToFloat(R2i.z),intBitsToFloat(R126i.w)),vec4(uf_blockVS6[11].x,uf_blockVS6[11].y,uf_blockVS6[11].z,uf_blockVS6[11].w)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R127i.y = floatBitsToInt(-(intBitsToFloat(PV0i.z)) + 1.0);
+PS1i = R127i.y;
+// 8
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),uf_blockVS7[9].y) + intBitsToFloat(R127i.x)));
+PV0i.x = R123i.x;
+PV0i.y = PV1i.x;
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) / 2.0);
+R123i.w = floatBitsToInt((intBitsToFloat(R125i.w) * 0.0 + intBitsToFloat(PV1i.x)));
+PV0i.w = R123i.w;
+// 9
+R123i.x = floatBitsToInt((intBitsToFloat(R125i.w) * 0.5 + intBitsToFloat(PV0i.y)));
+PV1i.x = R123i.x;
+PV1i.z = floatBitsToInt(fract(intBitsToFloat(PV0i.x)));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PV0i.w));
+// 10
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PV1i.z)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.x) * intBitsToFloat(PS1i));
+// 11
+PV1i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS6[18].w, intBitsToFloat(PV0i.y)));
+R2i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R16i.w),intBitsToFloat(R127i.y)) + intBitsToFloat(PV0i.x)));
+// 12
+PV0i.w = floatBitsToInt(-(uf_blockVS6[18].y) + intBitsToFloat(PV1i.x));
+// 13
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PV0i.w));
+// 14
+R5i.y = floatBitsToInt(-(uf_blockVS6[18].z) * intBitsToFloat(PS1i));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R0i.x;
+PV0i.x = floatBitsToInt(min(intBitsToFloat(backupReg0i), uf_blockVS7[116].x));
+R126i.z = floatBitsToInt(intBitsToFloat(R2i.w) + -(uf_blockVS7[60].w));
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[116].x);
+// 1
+R127i.x = floatBitsToInt(-(uf_blockVS7[60].y) + uf_blockVS7[61].y);
+R127i.y = floatBitsToInt(-(uf_blockVS7[60].x) + uf_blockVS7[61].x);
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.x) * intBitsToFloat(PS0i));
+// 2
+backupReg0i = R0i.y;
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.z), intBitsToFloat(PV1i.z)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.w), intBitsToFloat(PV1i.z)));
+R127i.z = floatBitsToInt(-(uf_blockVS7[60].z) + uf_blockVS7[61].z);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV1i.z)));
+PS0i = floatBitsToInt(-(uf_blockVS7[60].w) + uf_blockVS7[61].w);
+// 3
+R7i.x = floatBitsToInt(intBitsToFloat(R2i.x) + intBitsToFloat(PV0i.y));
+R7i.y = floatBitsToInt(intBitsToFloat(R9i.y) + intBitsToFloat(PV0i.x));
+R6i.z = floatBitsToInt(intBitsToFloat(R2i.z) + intBitsToFloat(PV0i.w));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 4
+PV0i.x = floatBitsToInt(intBitsToFloat(R127i.y) * intBitsToFloat(PS1i));
+R0i.y = ((intBitsToFloat(R126i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.z = floatBitsToInt(intBitsToFloat(R127i.z) * intBitsToFloat(PS1i));
+PV0i.w = floatBitsToInt(intBitsToFloat(R127i.x) * intBitsToFloat(PS1i));
+PS0i = floatBitsToInt(intBitsToFloat(R2i.w) + -(uf_blockVS7[61].w));
+// 5
+R2i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.z),intBitsToFloat(PV0i.w)) + uf_blockVS7[60].y));
+R2i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.z),intBitsToFloat(PV0i.x)) + uf_blockVS7[60].x));
+R2i.z = ((intBitsToFloat(PS0i) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R2i.z;
+R0i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.z),intBitsToFloat(PV0i.z)) + uf_blockVS7[60].z));
+// 6
+R2i.w = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 1.0);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R7i.x),intBitsToFloat(R7i.y),intBitsToFloat(R6i.z),intBitsToFloat(R3i.w)),vec4(uf_blockVS6[8].x,uf_blockVS6[8].y,uf_blockVS6[8].z,uf_blockVS6[8].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R5i.z = tempi.x;
+// 1
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R7i.x),intBitsToFloat(R7i.y),intBitsToFloat(R6i.z),intBitsToFloat(R3i.w)),vec4(uf_blockVS6[9].x,uf_blockVS6[9].y,uf_blockVS6[9].z,uf_blockVS6[9].w)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R6i.y = tempi.x;
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.y), intBitsToFloat(R2i.w)));
+PS1i = R126i.z;
+// 2
+backupReg0i = R0i.y;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R7i.x),intBitsToFloat(R7i.y),intBitsToFloat(R6i.z),intBitsToFloat(R3i.w)),vec4(uf_blockVS6[10].x,uf_blockVS6[10].y,uf_blockVS6[10].z,uf_blockVS6[10].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R9i.w = tempi.x;
+R127i.y = floatBitsToInt(-(intBitsToFloat(backupReg0i)) + 1.0);
+PS0i = R127i.y;
+// 3
+R11i.x = floatBitsToInt(dot(vec4(intBitsToFloat(R7i.x),intBitsToFloat(R7i.y),intBitsToFloat(R6i.z),intBitsToFloat(R3i.w)),vec4(uf_blockVS6[11].x,uf_blockVS6[11].y,uf_blockVS6[11].z,uf_blockVS6[11].w)));
+PV1i.x = R11i.x;
+PV1i.y = R11i.x;
+PV1i.z = R11i.x;
+PV1i.w = R11i.x;
+// 4
+R12i.x = floatBitsToInt((intBitsToFloat(R9i.w) * 0.0 + intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[60].x, intBitsToFloat(R127i.y)));
+PV0i.z = PV1i.x;
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) / 2.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[60].y, intBitsToFloat(R127i.y)));
+PS0i = floatBitsToInt(mul_nonIEEE(uf_blockVS7[60].z, intBitsToFloat(R127i.y)));
+// 5
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.x),intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.w)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.y),intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.y = R123i.y;
+R123i.z = floatBitsToInt((intBitsToFloat(R9i.w) * 0.0 + intBitsToFloat(PV0i.z)));
+PV1i.z = R123i.z;
+R125i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.w),intBitsToFloat(R126i.z)) + intBitsToFloat(PS0i)));
+R13i.w = floatBitsToInt((intBitsToFloat(R9i.w) * 0.5 + intBitsToFloat(PV0i.z)));
+PS1i = R13i.w;
+// 6
+R2i.x = floatBitsToInt((mul_nonIEEE(uf_blockVS7[61].x,intBitsToFloat(R2i.z)) + intBitsToFloat(PV1i.y)));
+R11i.y = floatBitsToInt((intBitsToFloat(R5i.z) * 0.5 + intBitsToFloat(PV1i.z)));
+R11i.z = floatBitsToInt((intBitsToFloat(R6i.y) * -(0.5) + intBitsToFloat(PV1i.z)));
+R0i.w = floatBitsToInt((mul_nonIEEE(uf_blockVS7[61].y,intBitsToFloat(R2i.z)) + intBitsToFloat(PV1i.x)));
+R11i.w = floatBitsToInt(1.0 / intBitsToFloat(R12i.x));
+PS0i = R11i.w;
+// 7
+PV1i.x = floatBitsToInt(intBitsToFloat(R13i.w) * intBitsToFloat(PS0i));
+R2i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS7[61].z,intBitsToFloat(R2i.z)) + intBitsToFloat(R125i.w)));
+// 8
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.x),uf_blockVS6[18].w) + -(uf_blockVS6[18].y)));
+PV0i.z = R123i.z;
+// 9
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PV0i.z));
+// 10
+R9i.x = floatBitsToInt(-(uf_blockVS6[18].z) * intBitsToFloat(PS1i));
+// 11
+R127i.x = floatBitsToInt(-(uf_blockVS7[68].x) + uf_blockVS7[69].x);
+// 12
+PV0i.w = floatBitsToInt(-(uf_blockVS7[68].w) + uf_blockVS7[69].w);
+// 13
+R126i.x = floatBitsToInt(-(uf_blockVS7[76].x) + uf_blockVS7[77].x);
+R125i.w = floatBitsToInt(-(uf_blockVS7[76].y) + uf_blockVS7[77].y);
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PV0i.w));
+// 14
+PV0i.x = floatBitsToInt(-(uf_blockVS7[76].w) + uf_blockVS7[77].w);
+R0i.y = floatBitsToInt(intBitsToFloat(R127i.x) * intBitsToFloat(PS1i));
+R126i.z = floatBitsToInt(-(uf_blockVS7[76].z) + uf_blockVS7[77].z);
+// 15
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PV0i.x));
+// 16
+R4i.y = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(PS1i));
+R0i.z = floatBitsToInt(intBitsToFloat(R125i.w) * intBitsToFloat(PS1i));
+R3i.w = floatBitsToInt(intBitsToFloat(R126i.x) * intBitsToFloat(PS1i));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R2i.x;
+R2i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), uf_blockVS8[0].x));
+R3i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.w), uf_blockVS8[0].y));
+PV0i.z = floatBitsToInt((0.0 > uf_blockVS7[8].y)?1.0:0.0);
+PV0i.w = floatBitsToInt((uf_blockVS7[8].y > 0.0)?1.0:0.0);
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[8].y);
+// 1
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), uf_blockVS8[0].z));
+R127i.y = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.z)));
+PV1i.y = R127i.y;
+PV1i.z = floatBitsToInt((uf_blockVS7[8].z > 0.0)?1.0:0.0);
+PV1i.w = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(PS0i));
+PS1i = floatBitsToInt((0.0 > uf_blockVS7[8].z)?1.0:0.0);
+// 2
+R126i.x = floatBitsToInt(-(intBitsToFloat(PV1i.y)) + 1.0);
+R126i.y = floatBitsToInt(intBitsToFloat(PV1i.z) + -(intBitsToFloat(PS1i)));
+PV0i.y = R126i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),uf_blockVS7[9].z) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[8].z);
+// 3
+R127i.x = floatBitsToInt(-(intBitsToFloat(PV0i.y)) + 1.0);
+PV1i.y = floatBitsToInt(fract(intBitsToFloat(PV0i.z)));
+PV1i.w = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(PS0i));
+// 4
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),uf_blockVS7[9].w) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV1i.y)));
+// 5
+PV1i.y = floatBitsToInt(fract(intBitsToFloat(PV0i.z)));
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R16i.w),intBitsToFloat(R126i.x)) + intBitsToFloat(PV0i.w)));
+// 6
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PV1i.y)));
+// 7
+R3i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R16i.w),intBitsToFloat(R127i.x)) + intBitsToFloat(PV0i.w)));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.y = floatBitsToInt(intBitsToFloat(R2i.z) + -(uf_blockVS7[68].w));
+PV0i.z = floatBitsToInt(intBitsToFloat(R2i.z) + -(uf_blockVS7[69].w));
+// 1
+R127i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.y),intBitsToFloat(R0i.y)) + uf_blockVS7[68].x));
+R126i.y = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.y = R126i.y;
+R7i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), uf_blockVS7[59].x));
+R125i.w = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R125i.w;
+R12i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.y), uf_blockVS7[59].x));
+PS1i = R12i.y;
+// 2
+backupReg0i = R0i.x;
+PV0i.x = floatBitsToInt(-(intBitsToFloat(PV1i.y)) + 1.0);
+R13i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), uf_blockVS7[59].x));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(PV1i.w)) + 1.0);
+R126i.w = floatBitsToInt(intBitsToFloat(R3i.z) + -(uf_blockVS7[76].w));
+PV0i.w = R126i.w;
+// 3
+R126i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.w),intBitsToFloat(R3i.w)) + uf_blockVS7[76].x));
+PV1i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[68].x, intBitsToFloat(PV0i.z)));
+R126i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.w),intBitsToFloat(R0i.z)) + uf_blockVS7[76].y));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.w), intBitsToFloat(PV0i.x)));
+R127i.y = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PS1i = R127i.y;
+// 4
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(PV1i.w)) + intBitsToFloat(PV1i.y)));
+PV0i.x = R123i.x;
+R125i.y = floatBitsToInt(intBitsToFloat(R3i.z) + -(uf_blockVS7[77].w));
+PV0i.y = R125i.y;
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.w),intBitsToFloat(R4i.y)) + uf_blockVS7[76].z));
+R125i.w = floatBitsToInt(-(intBitsToFloat(PS1i)) + 1.0);
+// 5
+R127i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R127i.x;
+PV1i.y = floatBitsToInt(intBitsToFloat(R3i.z) + -(uf_blockVS7[78].w));
+R123i.w = floatBitsToInt((mul_nonIEEE(uf_blockVS7[69].x,intBitsToFloat(R126i.y)) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+// 6
+PV0i.x = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + 1.0);
+R126i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[76].x, intBitsToFloat(R125i.w)));
+R124i.z = ((intBitsToFloat(PV1i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.z = R124i.z;
+R14i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), uf_blockVS8[0].w));
+R126i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[76].y, intBitsToFloat(R125i.w)));
+PS0i = R126i.w;
+// 7
+R125i.x = floatBitsToInt(-(uf_blockVS7[77].x) + uf_blockVS7[78].x);
+PV1i.y = floatBitsToInt(-(intBitsToFloat(PV0i.z)) + 1.0);
+R125i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV0i.x)));
+PV1i.z = R125i.z;
+R127i.w = floatBitsToInt(-(uf_blockVS7[77].y) + uf_blockVS7[78].y);
+// 8
+backupReg0i = R127i.x;
+backupReg1i = R126i.y;
+backupReg2i = R126i.z;
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV1i.y)));
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.x),intBitsToFloat(PV1i.z)) + intBitsToFloat(backupReg1i)));
+R126i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg2i),intBitsToFloat(PV1i.z)) + intBitsToFloat(R126i.w)));
+R126i.w = floatBitsToInt(-(uf_blockVS7[77].z) + uf_blockVS7[78].z);
+PS0i = floatBitsToInt(-(uf_blockVS7[77].w) + uf_blockVS7[78].w);
+// 9
+PV1i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[76].z, intBitsToFloat(R125i.w)));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 10
+PV0i.x = floatBitsToInt(intBitsToFloat(R125i.x) * intBitsToFloat(PS1i));
+PV0i.y = floatBitsToInt(intBitsToFloat(R126i.w) * intBitsToFloat(PS1i));
+PV0i.z = floatBitsToInt(intBitsToFloat(R127i.w) * intBitsToFloat(PS1i));
+R127i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(R125i.z)) + intBitsToFloat(PV1i.z)));
+// 11
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.y),intBitsToFloat(PV0i.x)) + uf_blockVS7[77].x));
+PV1i.x = R123i.x;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.y),intBitsToFloat(PV0i.y)) + uf_blockVS7[77].z));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.y),intBitsToFloat(PV0i.z)) + uf_blockVS7[77].y));
+PV1i.w = R123i.w;
+// 12
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.z),intBitsToFloat(R127i.x)) + intBitsToFloat(R127i.w)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.w),intBitsToFloat(R127i.x)) + intBitsToFloat(R126i.z)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.x),intBitsToFloat(R127i.x)) + intBitsToFloat(R126i.y)));
+PV0i.z = R123i.z;
+PV0i.w = ((intBitsToFloat(R8i.x) > 0.5)?int(0xFFFFFFFF):int(0x0));
+PS0i = ((intBitsToFloat(R8i.y) > 0.5)?int(0xFFFFFFFF):int(0x0));
+// 13
+R0i.x = ((PV0i.w == 0)?(R10i.x):(R10i.w));
+R123i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS7[78].z,intBitsToFloat(R124i.z)) + intBitsToFloat(PV0i.x)));
+PV1i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(uf_blockVS7[78].y,intBitsToFloat(R124i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(uf_blockVS7[78].x,intBitsToFloat(R124i.z)) + intBitsToFloat(PV0i.z)));
+PV1i.w = R123i.w;
+R2i.x = ((PS0i == 0)?(R10i.y):(R10i.z));
+PS1i = R2i.x;
+// 14
+PV0i.x = ((intBitsToFloat(R8i.z) > 0.5)?int(0xFFFFFFFF):int(0x0));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), uf_blockVS8[1].z));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.z), uf_blockVS8[1].y));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), uf_blockVS8[1].x));
+PS0i = ((intBitsToFloat(R8i.w) > 0.5)?int(0xFFFFFFFF):int(0x0));
+// 15
+R3i.x = ((PV0i.x == 0)?(R10i.x):(R10i.w));
+R14i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[59].x, intBitsToFloat(PV0i.y)));
+R12i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[59].x, intBitsToFloat(PV0i.z)));
+R12i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[59].x, intBitsToFloat(PV0i.w)));
+R3i.z = ((PS0i == 0)?(R10i.y):(R10i.z));
+PS1i = R3i.z;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt((uf_blockVS7[8].w > 0.0)?1.0:0.0);
+PV0i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x00080000;
+PV0i.w = floatBitsToInt((0.0 > uf_blockVS7[8].w)?1.0:0.0);
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[8].w);
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(PS0i));
+R125i.y = floatBitsToInt(-(uf_blockVS7[84].x) + uf_blockVS7[85].x);
+R124i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.w)));
+PV1i.z = R124i.z;
+PV1i.w = (PV0i.y == 0x00080000)?int(0xFFFFFFFF):int(0x0);
+// 2
+R5i.x = ((PV1i.w == 0)?(R10i.x):(R0i.x));
+R126i.y = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 1.0);
+PV0i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00100000;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),uf_blockVS7[10].x) + intBitsToFloat(PV1i.x)));
+PV0i.w = R123i.w;
+PS0i = ((intBitsToFloat(R8i.y) > 0.5)?int(0xFFFFFFFF):int(0x0));
+// 3
+PV1i.x = floatBitsToInt(-(uf_blockVS7[84].w) + uf_blockVS7[85].w);
+R127i.y = ((PS0i == 0)?(R10i.x):(R10i.w));
+PV1i.z = floatBitsToInt(fract(intBitsToFloat(PV0i.w)));
+PV1i.w = (PV0i.z == 0x00100000)?int(0xFFFFFFFF):int(0x0);
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), intBitsToFloat(PV1i.z)));
+PV0i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x00400000;
+PV0i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00200000;
+R5i.w = ((PV1i.w == 0)?(R10i.y):(R2i.x));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+// 5
+PV1i.x = (PV0i.y == 0x00400000)?int(0xFFFFFFFF):int(0x0);
+PV1i.y = (PV0i.z == 0x00200000)?int(0xFFFFFFFF):int(0x0);
+R124i.z = floatBitsToInt(intBitsToFloat(R125i.y) * intBitsToFloat(PS0i));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R16i.w),intBitsToFloat(R126i.y)) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(uf_blockVS7[5].x) & 0x00800000;
+// 6
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.w) + -(uf_blockVS7[84].w));
+R2i.y = ((PV1i.x == 0)?(R10i.y):(R3i.z));
+R4i.z = ((PV1i.y == 0)?(R10i.x):(R3i.x));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.w) + -(uf_blockVS7[85].w));
+PS0i = (PS1i == 0x00800000)?int(0xFFFFFFFF):int(0x0);
+// 7
+R6i.x = ((PS0i == 0)?(R10i.x):(R127i.y));
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),intBitsToFloat(R124i.z)) + uf_blockVS7[84].x));
+R124i.z = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R124i.z;
+R127i.w = ((intBitsToFloat(PV0i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R127i.w;
+PS1i = floatBitsToInt(uf_blockVS7[5].x) & 0x01000000;
+// 8
+PV0i.x = ((intBitsToFloat(R8i.z) > 0.5)?int(0xFFFFFFFF):int(0x0));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.w)) + 1.0);
+R126i.z = (PS1i == 0x01000000)?int(0xFFFFFFFF):int(0x0);
+PV0i.w = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 1.0);
+PS0i = floatBitsToInt(uf_blockVS7[5].y) & int(1);
+// 9
+R123i.x = ((PV0i.x == 0)?(R10i.y):(R10i.z));
+PV1i.x = R123i.x;
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), intBitsToFloat(PV0i.y)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[84].x, intBitsToFloat(PV0i.w)));
+R6i.w = (int(1) != PS0i)?int(0xFFFFFFFF):int(0x0);
+R3i.x = int(uf_blockVS7[17].x);
+PS1i = R3i.x;
+// 10
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.y),intBitsToFloat(PV1i.y)) + intBitsToFloat(PV1i.z)));
+PV0i.y = R123i.y;
+PV0i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00000010;
+R7i.w = ((R126i.z == 0)?(R10i.y):(PV1i.x));
+R0i.w = int(uf_blockVS7[17].y);
+PS0i = R0i.w;
+// 11
+R10i.x = floatBitsToInt((mul_nonIEEE(uf_blockVS7[85].x,intBitsToFloat(R127i.w)) + intBitsToFloat(PV0i.y)));
+PS1i = floatBitsToInt(float(PV0i.z));
+// 12
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00000020;
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+// 13
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.w)));
+PS1i = floatBitsToInt(float(PV0i.z));
+// 14
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R127i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R127i.y;
+// 15
+PV1i.x = 0 - PS0i;
+R3i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.w)));
+// 16
+R3i.w = max(R127i.y, PV1i.x);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R14i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R10i.x), uf_blockVS8[1].w));
+// 1
+R127i.x = floatBitsToInt(uf_blockVS7[5].x) & 0x00000080;
+R125i.y = int(-1) + R3i.x;
+PV1i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00000040;
+R127i.y = int(intBitsToFloat(R3i.z));
+PS1i = R127i.y;
+// 2
+PV0i.x = 0 - PS1i;
+R124i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x02000000;
+PS0i = floatBitsToInt(float(PV1i.z));
+// 3
+PV1i.x = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PV1i.y = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+R4i.w = max(R127i.y, PV0i.x);
+PS1i = floatBitsToInt(float(R127i.x));
+// 4
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R126i.z = floatBitsToInt(float(R3i.x));
+PS0i = R126i.z;
+// 5
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.x), intBitsToFloat(PS0i)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R15i.w), intBitsToFloat(PS0i)));
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.w)));
+R127i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R127i.y;
+// 6
+PV0i.x = 0 - PS1i;
+PV0i.y = floatBitsToInt(intBitsToFloat(R13i.x) * intBitsToFloat(PV1i.y));
+R126i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R126i.y;
+// 7
+PV1i.x = 0 - PS0i;
+R2i.w = max(R127i.y, PV0i.x);
+PS1i = int(intBitsToFloat(PV0i.y));
+// 8
+R126i.w = max(R126i.y, PV1i.x);
+R124i.z = R3i.w * PS1i;
+PS0i = R124i.z;
+// 9
+PS1i = floatBitsToInt(float(R0i.w));
+// 10
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PS1i));
+// 11
+PV1i.x = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(PS0i));
+R126i.y = floatBitsToInt(float(R3i.x));
+PS1i = R126i.y;
+// 12
+R3i.x = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+R125i.w = int(intBitsToFloat(PV1i.x));
+PS0i = R125i.w;
+// 13
+PS1i = floatBitsToInt(float(PS0i));
+// 14
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R126i.z)) + intBitsToFloat(PS1i));
+R125i.x = floatBitsToInt(float(R125i.w));
+PS0i = R125i.x;
+// 15
+R123i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R123i.x;
+R127i.w = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+R0i.w = floatBitsToInt(1.0 / abs(intBitsToFloat(R126i.y)));
+PS1i = R0i.w;
+// 16
+PV0i.z = floatBitsToInt(mul_nonIEEE(abs(intBitsToFloat(R125i.x)), intBitsToFloat(PS1i)));
+PS0i = int(intBitsToFloat(PV1i.x));
+// 17
+R124i.x = int(1) - PS0i;
+PV1i.y = floatBitsToInt(trunc(intBitsToFloat(PV0i.z)));
+R124i.w = PS0i * R125i.y;
+PS1i = R124i.w;
+// 18
+R126i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV1i.y)),intBitsToFloat(R3i.x)) + intBitsToFloat(R127i.w)));
+PV0i.z = R126i.z;
+PS0i = floatBitsToInt(float(R124i.y));
+// 19
+PV1i.x = floatBitsToInt((intBitsToFloat(PV0i.z) >= abs(intBitsToFloat(R126i.y)))?1.0:0.0);
+PV1i.y = floatBitsToInt(-(abs(intBitsToFloat(R126i.y))) + intBitsToFloat(PV0i.z));
+PV1i.z = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.w = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R126i.x = int(intBitsToFloat(R127i.x));
+PS1i = R126i.x;
+// 20
+backupReg0i = R126i.w;
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.w) + -(intBitsToFloat(PV1i.z)));
+R126i.w = ((intBitsToFloat(PV1i.x) == 0.0)?(R126i.z):(PV1i.y));
+PV0i.w = R126i.w;
+R124i.y = backupReg0i * PS1i;
+PS0i = R124i.y;
+// 21
+PV1i.z = floatBitsToInt(abs(intBitsToFloat(R126i.y)) + intBitsToFloat(PV0i.w));
+R127i.x = int(intBitsToFloat(PV0i.y));
+PS1i = R127i.x;
+// 22
+R123i.y = ((-(intBitsToFloat(R126i.w)) > 0.0)?(PV1i.z):(R126i.w));
+PV0i.y = R123i.y;
+PV0i.w = 0 - PS1i;
+// 23
+R123i.x = ((-(intBitsToFloat(R125i.x)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.y)))):(PV0i.y));
+PV1i.x = R123i.x;
+PV1i.z = max(R127i.x, PV0i.w);
+// 24
+R123i.w = ((intBitsToFloat(R126i.y) == 0.0)?(R125i.x):(PV1i.x));
+PV0i.w = R123i.w;
+PS0i = PV1i.z * R126i.x;
+// 25
+R126i.z = R125i.w + PS0i;
+PS1i = int(intBitsToFloat(PV0i.w));
+// 26
+PS0i = R124i.x * PS1i;
+// 27
+PV1i.z = PS0i + R124i.w;
+R124i.x = R2i.w * R126i.z;
+PS1i = R124i.x;
+// 28
+PS0i = R4i.w * PV1i.z;
+// 29
+PV1i.y = PS0i + R124i.z;
+// 30
+PV0i.x = R124i.x + PV1i.y;
+// 31
+PV1i.w = R124i.y + PV0i.x;
+// 32
+R126i.z = floatBitsToInt(float(PV1i.w));
+PS0i = R126i.z;
+// 33
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.w), abs(intBitsToFloat(PS0i))));
+R124i.w = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+// 34
+PV0i.x = floatBitsToInt(trunc(intBitsToFloat(PV1i.y)));
+// 35
+R124i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.x)),intBitsToFloat(R3i.x)) + intBitsToFloat(R124i.w)));
+PV1i.z = R124i.z;
+// 36
+PV0i.x = floatBitsToInt((intBitsToFloat(PV1i.z) >= abs(intBitsToFloat(R126i.y)))?1.0:0.0);
+PV0i.y = floatBitsToInt(-(abs(intBitsToFloat(R126i.y))) + intBitsToFloat(PV1i.z));
+// 37
+R124i.w = ((intBitsToFloat(PV0i.x) == 0.0)?(R124i.z):(PV0i.y));
+PV1i.w = R124i.w;
+// 38
+PV0i.z = floatBitsToInt(abs(intBitsToFloat(R126i.y)) + intBitsToFloat(PV1i.w));
+// 39
+R123i.y = ((-(intBitsToFloat(R124i.w)) > 0.0)?(PV0i.z):(R124i.w));
+PV1i.y = R123i.y;
+// 40
+R123i.x = ((-(intBitsToFloat(R126i.z)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV1i.y)))):(PV1i.y));
+PV0i.x = R123i.x;
+// 41
+R123i.w = ((intBitsToFloat(R126i.y) == 0.0)?(R126i.z):(PV0i.x));
+PV1i.w = R123i.w;
+// 42
+R126i.z = int(intBitsToFloat(PV1i.w));
+PS0i = R126i.z;
+// 43
+R126i.y = floatBitsToInt(float(PS0i));
+PS1i = R126i.y;
+// 44
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R2i.x = floatBitsToInt(float(R126i.z));
+PS0i = R2i.x;
+// 45
+R124i.y = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.w)));
+PV1i.w = floatBitsToInt(abs(intBitsToFloat(PS0i)) * 0.25);
+// 46
+R123i.y = floatBitsToInt((intBitsToFloat(PV1i.z) * 0.5 + intBitsToFloat(R126i.y)));
+PV0i.y = R123i.y;
+PV0i.z = floatBitsToInt(trunc(intBitsToFloat(PV1i.w)));
+// 47
+R3i.x = floatBitsToInt((-(intBitsToFloat(PV0i.z)) * 4.0 + intBitsToFloat(R124i.y)));
+PV1i.x = R3i.x;
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 0.25);
+R0i.z = ((R6i.w == 0)?(R8i.x):(R8i.y));
+// 48
+R10i.x = floatBitsToInt(trunc(intBitsToFloat(PV1i.y)));
+R3i.z = floatBitsToInt((intBitsToFloat(PV1i.x) >= 4.0)?1.0:0.0);
+R0i.w = floatBitsToInt(intBitsToFloat(PV1i.x) + intBitsToFloat(0xc0800000));
+R0i.y = int(uf_blockVS7[26].x);
+PS0i = R0i.y;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R124i.y = ((intBitsToFloat(R3i.z) == 0.0)?(R3i.x):(R0i.w));
+PV0i.y = R124i.y;
+PS0i = int(intBitsToFloat(R10i.x));
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.y) + 4.0);
+R10i.y = PS0i + 0x00000012;
+PV1i.w = floatBitsToInt(uf_blockVS7[5].x) & 0x00000100;
+R0i.x = int(uf_blockVS7[26].y);
+PS1i = R0i.x;
+// 2
+R123i.w = ((-(intBitsToFloat(R124i.y)) > 0.0)?(PV1i.x):(R124i.y));
+PV0i.w = R123i.w;
+R126i.z = floatBitsToInt(float(PV1i.w));
+PS0i = R126i.z;
+// 3
+R124i.y = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R123i.z = ((-(intBitsToFloat(R2i.x)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.w)))):(PV0i.w));
+PV1i.z = R123i.z;
+// 4
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(R126i.z))?1.0:0.0);
+PS0i = int(intBitsToFloat(PV1i.z));
+// 5
+backupReg0i = R124i.y;
+PV1i.x = int(-1) + PS0i;
+R124i.y = 0xfffffffe + PS0i;
+R126i.z = 0xfffffffd + PS0i;
+R125i.w = floatBitsToInt(intBitsToFloat(backupReg0i) + -(intBitsToFloat(PV0i.x)));
+PS1i = floatBitsToInt(float(PS0i));
+// 6
+R126i.x = floatBitsToInt(uf_blockVS7[5].x) & 0x00000200;
+PV0i.z = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.w = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PS0i = floatBitsToInt(float(PV1i.x));
+// 7
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.z)));
+PV1i.z = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PS1i = floatBitsToInt(float(R124i.y));
+// 8
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.z) + -(intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.z = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R124i.x = int(intBitsToFloat(PV1i.y));
+PS0i = R124i.x;
+// 9
+PV1i.x = 0 - PS0i;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.z)));
+R124i.w = int(intBitsToFloat(PV0i.x));
+PS1i = R124i.w;
+// 10
+PV0i.x = 0 - PS1i;
+PV0i.z = max(R124i.x, PV1i.x);
+R124i.z = int(intBitsToFloat(PV1i.w));
+PS0i = R124i.z;
+// 11
+R2i.x = int(1) - PV0i.z;
+PV1i.y = max(R124i.w, PV0i.x);
+PV1i.z = 0 - PS0i;
+PS1i = floatBitsToInt(float(R126i.z));
+// 12
+PV0i.x = max(R124i.z, PV1i.z);
+R4i.y = int(1) - PV1i.y;
+PV0i.z = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R124i.z = int(intBitsToFloat(R125i.w));
+PS0i = R124i.z;
+// 13
+PV1i.y = 0 - PS0i;
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.z) + -(intBitsToFloat(PV0i.w)));
+R0i.w = int(1) - PV0i.x;
+PS1i = floatBitsToInt(float(R126i.x));
+// 14
+R3i.x = max(R124i.z, PV1i.y);
+PV0i.y = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.z = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R124i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R124i.y;
+// 15
+PV1i.x = 0 - PS0i;
+R4i.w = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.z)));
+// 16
+PV0i.w = max(R124i.y, PV1i.x);
+// 17
+R3i.z = int(1) - PV0i.w;
+}
+if( activeMaskStackC[3] == true ) {
+R10i.xyzw = floatBitsToInt(uf_blockVS7[R10i.y].xyzw);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R124i.x = floatBitsToInt(uf_blockVS7[5].x) & 0x00000800;
+R126i.y = int(-1) + R0i.y;
+R124i.w = floatBitsToInt(uf_blockVS7[5].x) & 0x00000400;
+R124i.y = R3i.z * R10i.w;
+PS0i = R124i.y;
+// 1
+R126i.x = R0i.w * R10i.z;
+PS1i = R126i.x;
+// 2
+R125i.w = R4i.y * R10i.y;
+PS0i = R125i.w;
+// 3
+PS1i = R2i.x * R10i.x;
+// 4
+PV0i.y = R125i.w + PS1i;
+R124i.z = int(intBitsToFloat(R4i.w));
+PS0i = R124i.z;
+// 5
+PV1i.x = R126i.x + PV0i.y;
+PV1i.y = 0 - PS0i;
+PS1i = floatBitsToInt(float(R124i.w));
+// 6
+R10i.x = max(R124i.z, PV1i.y);
+PV0i.y = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.z = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R10i.w = R124i.y + PV1i.x;
+PS0i = floatBitsToInt(float(R124i.x));
+// 7
+backupReg0i = R0i.y;
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.y = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R127i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x04000000;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.z)));
+R124i.w = floatBitsToInt(float(backupReg0i));
+PS1i = R124i.w;
+// 8
+R126i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.z), intBitsToFloat(PS1i)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R15i.w), intBitsToFloat(PS1i)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(PV1i.x)));
+R124i.z = int(intBitsToFloat(PV1i.w));
+PS0i = R124i.z;
+// 9
+PV1i.x = 0 - PS0i;
+PV1i.y = floatBitsToInt(intBitsToFloat(R13i.x) * intBitsToFloat(PV0i.z));
+R126i.z = int(intBitsToFloat(PV0i.w));
+PS1i = R126i.z;
+// 10
+R2i.x = max(R124i.z, PV1i.x);
+PV0i.y = 0 - PS1i;
+PS0i = int(intBitsToFloat(PV1i.y));
+// 11
+R125i.x = max(R126i.z, PV0i.y);
+R125i.w = R3i.x * PS0i;
+PS1i = R125i.w;
+// 12
+backupReg0i = R0i.x;
+PS0i = floatBitsToInt(float(backupReg0i));
+// 13
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 14
+backupReg0i = R0i.y;
+PV0i.y = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(PS1i));
+R126i.z = floatBitsToInt(float(backupReg0i));
+PS0i = R126i.z;
+// 15
+R127i.y = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+R127i.x = int(intBitsToFloat(PV0i.y));
+PS1i = R127i.x;
+// 16
+PS0i = floatBitsToInt(float(PS1i));
+// 17
+PV1i.z = floatBitsToInt(-(intBitsToFloat(R124i.w)) + intBitsToFloat(PS0i));
+R124i.y = floatBitsToInt(float(R127i.x));
+PS1i = R124i.y;
+// 18
+R124i.x = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+R123i.y = ((intBitsToFloat(PV1i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.y = R123i.y;
+R4i.x = floatBitsToInt(1.0 / abs(intBitsToFloat(R126i.z)));
+PS0i = R4i.x;
+// 19
+PV1i.w = floatBitsToInt(mul_nonIEEE(abs(intBitsToFloat(R124i.y)), intBitsToFloat(PS0i)));
+PS1i = int(intBitsToFloat(PV0i.y));
+// 20
+R0i.x = int(1) - PS1i;
+PV0i.z = floatBitsToInt(trunc(intBitsToFloat(PV1i.w)));
+R3i.x = PS1i * R126i.y;
+PS0i = R3i.x;
+// 21
+R124i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.z)),intBitsToFloat(R127i.y)) + intBitsToFloat(R124i.x)));
+PV1i.w = R124i.w;
+PS1i = floatBitsToInt(float(R127i.z));
+// 22
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.y = floatBitsToInt((intBitsToFloat(PV1i.w) >= abs(intBitsToFloat(R126i.z)))?1.0:0.0);
+PV0i.z = floatBitsToInt(-(abs(intBitsToFloat(R126i.z))) + intBitsToFloat(PV1i.w));
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R125i.y = int(intBitsToFloat(R126i.x));
+PS0i = R125i.y;
+// 23
+backupReg0i = R125i.x;
+R125i.x = ((intBitsToFloat(PV0i.y) == 0.0)?(R124i.w):(PV0i.z));
+PV1i.x = R125i.x;
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.w)));
+R127i.z = backupReg0i * PS0i;
+PS1i = R127i.z;
+// 24
+PV0i.w = floatBitsToInt(abs(intBitsToFloat(R126i.z)) + intBitsToFloat(PV1i.x));
+R126i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R126i.y;
+// 25
+PV1i.x = 0 - PS0i;
+R123i.z = ((-(intBitsToFloat(R125i.x)) > 0.0)?(PV0i.w):(R125i.x));
+PV1i.z = R123i.z;
+// 26
+R123i.y = ((-(intBitsToFloat(R124i.y)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV1i.z)))):(PV1i.z));
+PV0i.y = R123i.y;
+PV0i.w = max(R126i.y, PV1i.x);
+// 27
+R123i.x = ((intBitsToFloat(R126i.z) == 0.0)?(R124i.y):(PV0i.y));
+PV1i.x = R123i.x;
+PS1i = PV0i.w * R125i.y;
+// 28
+R124i.w = R127i.x + PS1i;
+PS0i = int(intBitsToFloat(PV1i.x));
+// 29
+backupReg0i = R0i.x;
+PS1i = backupReg0i * PS0i;
+// 30
+PV0i.w = PS1i + R3i.x;
+R125i.y = R2i.x * R124i.w;
+PS0i = R125i.y;
+// 31
+PS1i = R10i.x * PV0i.w;
+// 32
+PV0i.z = PS1i + R125i.w;
+// 33
+PV1i.y = R125i.y + PV0i.z;
+// 34
+PV0i.x = R127i.z + PV1i.y;
+// 35
+R124i.w = floatBitsToInt(float(PV0i.x));
+PS1i = R124i.w;
+// 36
+R127i.x = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R4i.x), abs(intBitsToFloat(PS1i))));
+// 37
+PV1i.y = floatBitsToInt(trunc(intBitsToFloat(PV0i.z)));
+// 38
+R125i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV1i.y)),intBitsToFloat(R127i.y)) + intBitsToFloat(R127i.x)));
+PV0i.w = R125i.w;
+// 39
+PV1i.y = floatBitsToInt((intBitsToFloat(PV0i.w) >= abs(intBitsToFloat(R126i.z)))?1.0:0.0);
+PV1i.z = floatBitsToInt(-(abs(intBitsToFloat(R126i.z))) + intBitsToFloat(PV0i.w));
+// 40
+R127i.x = ((intBitsToFloat(PV1i.y) == 0.0)?(R125i.w):(PV1i.z));
+PV0i.x = R127i.x;
+// 41
+PV1i.w = floatBitsToInt(abs(intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.x));
+// 42
+R123i.z = ((-(intBitsToFloat(R127i.x)) > 0.0)?(PV1i.w):(R127i.x));
+PV0i.z = R123i.z;
+// 43
+R123i.y = ((-(intBitsToFloat(R124i.w)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.z)))):(PV0i.z));
+PV1i.y = R123i.y;
+// 44
+R123i.x = ((intBitsToFloat(R126i.z) == 0.0)?(R124i.w):(PV1i.y));
+PV0i.x = R123i.x;
+// 45
+R124i.w = int(intBitsToFloat(PV0i.x));
+PS1i = R124i.w;
+// 46
+R0i.z = floatBitsToInt(float(PS1i));
+PS0i = R0i.z;
+// 47
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.y = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R0i.y = floatBitsToInt(float(R124i.w));
+PS1i = R0i.y;
+// 48
+R4i.x = floatBitsToInt(abs(intBitsToFloat(PS1i)) * 0.25);
+R10i.z = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+R4i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(PV1i.x)));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R123i.z = floatBitsToInt((intBitsToFloat(R4i.w) * 0.5 + intBitsToFloat(R0i.z)));
+PV0i.z = R123i.z;
+PV0i.w = floatBitsToInt(trunc(intBitsToFloat(R4i.x)));
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.z) * 0.25);
+R127i.y = floatBitsToInt((-(intBitsToFloat(PV0i.w)) * 4.0 + intBitsToFloat(R10i.z)));
+PV1i.y = R127i.y;
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.y) + intBitsToFloat(0xc0800000));
+PV0i.y = floatBitsToInt(trunc(intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt((intBitsToFloat(PV1i.y) >= 4.0)?1.0:0.0);
+// 3
+R126i.z = ((intBitsToFloat(PV0i.w) == 0.0)?(R127i.y):(PV0i.x));
+PV1i.z = R126i.z;
+PS1i = int(intBitsToFloat(PV0i.y));
+// 4
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.z) + 4.0);
+R10i.z = PS1i + 0x0000001b;
+PS0i = int(uf_blockVS7[48].z);
+// 5
+R123i.x = ((-(intBitsToFloat(R126i.z)) > 0.0)?(PV0i.y):(R126i.z));
+PV1i.x = R123i.x;
+R2i.z = floatBitsToInt(float(PS0i));
+PS1i = R2i.z;
+// 6
+R123i.w = ((-(intBitsToFloat(R0i.y)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV1i.x)))):(PV1i.x));
+PV0i.w = R123i.w;
+R0i.y = floatBitsToInt(float(R10i.w));
+PS0i = R0i.y;
+// 7
+PS1i = int(intBitsToFloat(PV0i.w));
+// 8
+R127i.x = 0xfffffffe + PS1i;
+PV0i.y = int(-1) + PS1i;
+R126i.z = floatBitsToInt(abs(intBitsToFloat(R2i.z)));
+R124i.w = 0xfffffffd + PS1i;
+PS0i = floatBitsToInt(float(PS1i));
+// 9
+PV1i.x = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PV1i.w = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PS1i = floatBitsToInt(float(PV0i.y));
+// 10
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.x) + -(intBitsToFloat(PV1i.w)));
+PV0i.w = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PS0i = floatBitsToInt(float(R127i.x));
+// 11
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.x)));
+PV1i.z = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R127i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R127i.y;
+// 12
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.z) + -(intBitsToFloat(PV1i.x)));
+PV0i.y = 0 - PS1i;
+R127i.x = int(intBitsToFloat(PV1i.y));
+PS0i = R127i.x;
+// 13
+PV1i.x = 0 - PS0i;
+PV1i.w = max(R127i.y, PV0i.y);
+R125i.w = int(intBitsToFloat(PV0i.x));
+PS1i = R125i.w;
+// 14
+R2i.x = int(1) - PV1i.w;
+PV0i.y = 0 - PS1i;
+PV0i.z = max(R127i.x, PV1i.x);
+PS0i = floatBitsToInt(float(R124i.w));
+// 15
+R10i.x = int(1) - PV0i.z;
+PV1i.y = max(R125i.w, PV0i.y);
+PV1i.z = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PV1i.w = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+R0i.x = floatBitsToInt(float(R10i.w));
+PS1i = R0i.x;
+// 16
+R4i.x = int(1) - PV1i.y;
+R127i.y = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.z) + -(intBitsToFloat(PV1i.w)));
+PS0i = floatBitsToInt(1.0 / abs(intBitsToFloat(R2i.z)));
+// 17
+PV1i.z = floatBitsToInt(mul_nonIEEE(abs(intBitsToFloat(R0i.x)), intBitsToFloat(PS0i)));
+R127i.z = int(intBitsToFloat(PV0i.w));
+PS1i = R127i.z;
+// 18
+PV0i.x = floatBitsToInt(trunc(intBitsToFloat(PV1i.z)));
+PV0i.y = 0 - PS1i;
+// 19
+PV1i.x = max(R127i.z, PV0i.y);
+R127i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.x)),intBitsToFloat(R126i.z)) + intBitsToFloat(R127i.y)));
+PV1i.z = R127i.z;
+// 20
+PV0i.x = floatBitsToInt((intBitsToFloat(PV1i.z) >= abs(intBitsToFloat(R2i.z)))?1.0:0.0);
+PV0i.y = floatBitsToInt(-(abs(intBitsToFloat(R2i.z))) + intBitsToFloat(PV1i.z));
+R10i.w = int(1) - PV1i.x;
+// 21
+R4i.w = ((intBitsToFloat(PV0i.x) == 0.0)?(R127i.z):(PV0i.y));
+PV1i.w = R4i.w;
+// 22
+R0i.z = floatBitsToInt(abs(intBitsToFloat(R2i.z)) + intBitsToFloat(PV1i.w));
+}
+if( activeMaskStackC[3] == true ) {
+R3i.xyzw = floatBitsToInt(uf_blockVS7[R10i.z].xyzw);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R0i.y;
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(R0i.y))?1.0:0.0);
+PV0i.y = floatBitsToInt((intBitsToFloat(backupReg0i) > 0.0)?1.0:0.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.x), uf_blockVS7[45].x));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV0i.z) * 2.0);
+PV0i.w = floatBitsToInt(uf_blockVS7[44].z + uf_blockVS7[45].x);
+R126i.z = R10i.w * R3i.w;
+PS0i = R126i.z;
+// 1
+R125i.x = floatBitsToInt(-(intBitsToFloat(PV0i.z)) + intBitsToFloat(PV0i.w));
+R123i.y = ((-(intBitsToFloat(R4i.w)) > 0.0)?(R0i.z):(R4i.w));
+PV1i.y = R123i.y;
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.y), uf_blockVS7[45].y));
+R127i.z = floatBitsToInt(intBitsToFloat(R127i.z) * 2.0);
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.x)));
+R127i.y = R4i.x * R3i.z;
+PS1i = R127i.y;
+// 2
+backupReg0i = R0i.y;
+R123i.x = ((-(intBitsToFloat(R0i.x)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV1i.y)))):(PV1i.y));
+PV0i.x = R123i.x;
+PV0i.y = floatBitsToInt(uf_blockVS7[44].w + uf_blockVS7[45].y);
+R124i.z = floatBitsToInt((intBitsToFloat(PV1i.w) * 0.5 + intBitsToFloat(backupReg0i)));
+R127i.x = R10i.x * R3i.y;
+PS0i = R127i.x;
+// 3
+R126i.x = floatBitsToInt(-(intBitsToFloat(R127i.z)) + intBitsToFloat(PV0i.y));
+PV1i.y = floatBitsToInt(uf_blockVS7[46].x + uf_blockVS7[46].z);
+PV1i.z = floatBitsToInt(uf_blockVS7[46].y + uf_blockVS7[46].w);
+R123i.w = ((intBitsToFloat(R2i.z) == 0.0)?(R0i.x):(PV0i.x));
+PV1i.w = R123i.w;
+PS1i = R2i.x * R3i.x;
+// 4
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),uf_blockVS7[46].z) + intBitsToFloat(PV1i.y)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.y),uf_blockVS7[46].w) + intBitsToFloat(PV1i.z)));
+PV0i.y = R123i.y;
+PV0i.z = R127i.x + PS1i;
+R125i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R15i.w)),uf_blockVS7[44].x) + -(intBitsToFloat(R125i.x))));
+R127i.z = int(intBitsToFloat(PV1i.w));
+PS0i = R127i.z;
+// 5
+R125i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[45].z) + intBitsToFloat(PV0i.x)));
+PV1i.y = R127i.y + PV0i.z;
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[45].w) + intBitsToFloat(PV0i.y)));
+R124i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[44].y) + intBitsToFloat(R126i.x)));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(R2i.z));
+// 6
+R124i.x = R126i.z + PV1i.y;
+PV0i.y = floatBitsToInt(intBitsToFloat(R124i.z) * intBitsToFloat(PS1i));
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[48].z);
+// 7
+R126i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[48].x, intBitsToFloat(PS0i)));
+PV1i.x = R126i.x;
+R123i.y = ((R6i.w == 0)?(0):(int(1)));
+PV1i.y = R123i.y;
+PV1i.w = floatBitsToInt(trunc(intBitsToFloat(PV0i.y)));
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[48].w);
+// 8
+R127i.x = (PV1i.y == int(1))?int(0xFFFFFFFF):int(0x0);
+PV0i.x = R127i.x;
+PV0i.y = (PV1i.y == 0x00000002)?int(0xFFFFFFFF):int(0x0);
+R124i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[48].y, intBitsToFloat(PS1i)));
+PV0i.z = R124i.z;
+R126i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.x)) + -(0.5)));
+R126i.z = int(intBitsToFloat(PV1i.w));
+PS0i = R126i.z;
+// 9
+backupReg0i = R127i.z;
+R123i.x = ((PV0i.y == 0)?(R8i.x):(R8i.z));
+PV1i.x = R123i.x;
+R127i.y = ((PV0i.x == 0)?(R8i.x):(R8i.y));
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(PV0i.z)) + -(0.5)));
+R123i.w = ((PV0i.y == 0)?(R8i.y):(R8i.x));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(float(backupReg0i));
+// 10
+R123i.x = ((R127i.x == 0)?(PV1i.w):(R8i.z));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.x),intBitsToFloat(PS1i)) + intBitsToFloat(R125i.w)));
+PV0i.y = R123i.y;
+R123i.z = ((R127i.x == 0)?(PV1i.x):(R8i.y));
+PV0i.z = R123i.z;
+R125i.w = ((R127i.x == 0)?(R8i.y):(R8i.z));
+PS0i = floatBitsToInt(float(R126i.z));
+// 11
+backupReg0i = R125i.x;
+R125i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[50].x, intBitsToFloat(PV0i.z)));
+R125i.x = floatBitsToInt(intBitsToFloat(R125i.x) * 2.0);
+R10i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(R126i.w)) + intBitsToFloat(PV0i.y)));
+R123i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R124i.z)),intBitsToFloat(PS0i)) + intBitsToFloat(R124i.w)));
+PV1i.z = R123i.z;
+R126i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[50].y, intBitsToFloat(PV0i.x)));
+R126i.w = floatBitsToInt(intBitsToFloat(R126i.w) * 2.0);
+PS1i = int(uf_blockVS7[53].z);
+// 12
+R5i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.z),intBitsToFloat(R127i.z)) + -(intBitsToFloat(PV1i.z))));
+PV0i.y = floatBitsToInt(uf_blockVS7[49].w + uf_blockVS7[50].y);
+PV0i.w = floatBitsToInt(uf_blockVS7[49].z + uf_blockVS7[50].x);
+R126i.y = floatBitsToInt(float(PS1i));
+PS0i = R126i.y;
+// 13
+backupReg0i = R126i.w;
+R127i.x = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+PV1i.y = floatBitsToInt(uf_blockVS7[51].x + uf_blockVS7[51].z);
+R127i.z = floatBitsToInt(-(intBitsToFloat(R125i.x)) + intBitsToFloat(PV0i.w));
+R126i.w = floatBitsToInt(-(intBitsToFloat(backupReg0i)) + intBitsToFloat(PV0i.y));
+R125i.x = floatBitsToInt(float(R124i.x));
+PS1i = R125i.x;
+// 14
+backupReg0i = R127i.y;
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+R127i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS7[51].z,intBitsToFloat(backupReg0i)) + intBitsToFloat(PV1i.y)));
+PV0i.z = floatBitsToInt(uf_blockVS7[51].y + uf_blockVS7[51].w);
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R124i.w = floatBitsToInt(float(R124i.x));
+PS0i = R124i.w;
+// 15
+backupReg0i = R125i.w;
+R124i.x = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+R3i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R15i.w)),uf_blockVS7[49].x) + -(intBitsToFloat(R127i.z))));
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.w)));
+R125i.w = floatBitsToInt((mul_nonIEEE(uf_blockVS7[51].w,intBitsToFloat(backupReg0i)) + intBitsToFloat(PV0i.z)));
+PS1i = floatBitsToInt(1.0 / abs(intBitsToFloat(R126i.y)));
+// 16
+PV0i.x = floatBitsToInt(mul_nonIEEE(abs(intBitsToFloat(R124i.w)), intBitsToFloat(PS1i)));
+R123i.y = floatBitsToInt((intBitsToFloat(PV1i.z) * 0.5 + intBitsToFloat(R125i.x)));
+PV0i.y = R123i.y;
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[49].y) + intBitsToFloat(R126i.w)));
+R5i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[50].z) + intBitsToFloat(R127i.y)));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(R126i.y));
+// 17
+PV1i.x = floatBitsToInt(trunc(intBitsToFloat(PV0i.x)));
+R124i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[50].w) + intBitsToFloat(R125i.w)));
+R127i.z = ((R6i.w == 0)?(0):(0x00000002));
+PV1i.z = R127i.z;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(PS0i));
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[53].z);
+// 18
+backupReg0i = R127i.x;
+R127i.x = (PV1i.z == int(1))?int(0xFFFFFFFF):int(0x0);
+R127i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV1i.x)),intBitsToFloat(backupReg0i)) + intBitsToFloat(R124i.x)));
+PV0i.y = R127i.y;
+PV0i.z = floatBitsToInt(trunc(intBitsToFloat(PV1i.w)));
+R6i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[53].x, intBitsToFloat(PS1i)));
+PV0i.w = R6i.w;
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[53].w);
+// 19
+backupReg0i = R4i.z;
+PV1i.x = floatBitsToInt(-(abs(intBitsToFloat(R126i.y))) + intBitsToFloat(PV0i.y));
+R125i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[53].y, intBitsToFloat(PS0i)));
+PV1i.y = R125i.y;
+R4i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(PV0i.w)) + -(0.5)));
+PV1i.w = floatBitsToInt((intBitsToFloat(PV0i.y) >= abs(intBitsToFloat(R126i.y)))?1.0:0.0);
+PS1i = int(intBitsToFloat(PV0i.z));
+// 20
+backupReg0i = R127i.y;
+PV0i.x = (R127i.z == 0x00000002)?int(0xFFFFFFFF):int(0x0);
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.y),intBitsToFloat(PV1i.y)) + -(0.5)));
+R127i.z = ((intBitsToFloat(PV1i.w) == 0.0)?(backupReg0i):(PV1i.x));
+PV0i.z = R127i.z;
+R4i.w = ((R127i.x == 0)?(R8i.x):(R8i.y));
+PS0i = floatBitsToInt(float(PS1i));
+// 21
+PV1i.x = floatBitsToInt(abs(intBitsToFloat(R126i.y)) + intBitsToFloat(PV0i.z));
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R125i.y)),intBitsToFloat(PS0i)) + intBitsToFloat(R125i.z)));
+PV1i.y = R123i.y;
+R123i.z = ((PV0i.x == 0)?(R8i.y):(R8i.x));
+PV1i.z = R123i.z;
+R123i.w = ((PV0i.x == 0)?(R8i.x):(R8i.z));
+PV1i.w = R123i.w;
+R2i.z = ((R127i.x == 0)?(R8i.y):(R8i.z));
+PS1i = R2i.z;
+// 22
+backupReg0i = R8i.z;
+R123i.x = ((-(intBitsToFloat(R127i.z)) > 0.0)?(PV1i.x):(R127i.z));
+PV0i.x = R123i.x;
+R2i.y = ((R127i.x == 0)?(PV1i.w):(R8i.y));
+R8i.z = ((R127i.x == 0)?(PV1i.z):(backupReg0i));
+R3i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.y),intBitsToFloat(R127i.y)) + -(intBitsToFloat(PV1i.y))));
+PS0i = int(uf_blockVS7[58].z);
+// 23
+R123i.w = ((-(intBitsToFloat(R124i.w)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.x)))):(PV0i.x));
+PV1i.w = R123i.w;
+R8i.x = floatBitsToInt(float(PS0i));
+PS1i = R8i.x;
+// 24
+PV0i.x = floatBitsToInt((0.0 >= abs(intBitsToFloat(PS1i)))?1.0:0.0);
+R123i.z = ((intBitsToFloat(R126i.y) == 0.0)?(R124i.w):(PV1i.w));
+PV0i.z = R123i.z;
+PV0i.w = floatBitsToInt(-(abs(intBitsToFloat(PS1i))) + 0.0);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PS1i));
+// 25
+R0i.y = ((intBitsToFloat(PV0i.x) == 0.0)?(0):(PV0i.w));
+R8i.w = floatBitsToInt(intBitsToFloat(PS0i) * 0.0);
+R8i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R8i.y;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(abs(intBitsToFloat(R8i.x)) + intBitsToFloat(R0i.y));
+PV0i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[55].x, intBitsToFloat(R2i.y)));
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) * 2.0);
+PV0i.z = floatBitsToInt(trunc(intBitsToFloat(R8i.w)));
+PV0i.w = floatBitsToInt(uf_blockVS7[54].z + uf_blockVS7[55].x);
+PS0i = floatBitsToInt(float(R8i.y));
+// 1
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.w),intBitsToFloat(PS0i)) + intBitsToFloat(R3i.y)));
+PV1i.x = R123i.x;
+R125i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[55].y, intBitsToFloat(R8i.z)));
+R125i.y = floatBitsToInt(intBitsToFloat(R125i.y) * 2.0);
+PV1i.z = floatBitsToInt(-(intBitsToFloat(PV0i.y)) + intBitsToFloat(PV0i.w));
+R123i.w = ((-(intBitsToFloat(R0i.y)) > 0.0)?(PV0i.x):(R0i.y));
+PV1i.w = R123i.w;
+R124i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R124i.y;
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(R4i.z)) + intBitsToFloat(PV1i.x)));
+PV0i.x = R123i.x;
+R127i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R15i.w)),uf_blockVS7[54].x) + -(intBitsToFloat(PV1i.z))));
+R123i.z = ((intBitsToFloat(R8i.x) == 0.0)?(0):(PV1i.w));
+PV0i.z = R123i.z;
+R6i.w = floatBitsToInt(intBitsToFloat(R10i.y) + 0.5);
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[58].z);
+// 3
+R2i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + 0.5);
+R2i.y = floatBitsToInt(intBitsToFloat(R5i.x) + 0.5);
+R8i.z = floatBitsToInt(intBitsToFloat(R3i.w) + 0.5);
+R124i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[58].x, intBitsToFloat(PS0i)));
+PV1i.w = R124i.w;
+R126i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R126i.y;
+// 4
+R127i.x = floatBitsToInt(intBitsToFloat(R5i.y) + -(uf_blockVS7[93].x));
+R5i.y = floatBitsToInt(-(uf_blockVS7[93].x) + uf_blockVS7[93].y);
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.x),intBitsToFloat(PV1i.w)) + -(0.5)));
+R126i.w = floatBitsToInt(intBitsToFloat(R16i.w) + 0.0);
+PV0i.w = R126i.w;
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[58].w);
+// 5
+backupReg0i = R126i.y;
+R125i.x = floatBitsToInt(intBitsToFloat(PV0i.w) + -(uf_blockVS7[104].w));
+R126i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[58].y, intBitsToFloat(PS0i)));
+PV1i.y = R126i.y;
+PS1i = floatBitsToInt(float(backupReg0i));
+// 6
+R124i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.w),intBitsToFloat(PS1i)) + intBitsToFloat(R127i.y)));
+PV0i.y = floatBitsToInt(uf_blockVS7[54].w + uf_blockVS7[55].y);
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R7i.w),intBitsToFloat(PV1i.y)) + -(0.5)));
+R124i.w = floatBitsToInt(float(R124i.y));
+PS0i = R124i.w;
+// 7
+PV1i.x = floatBitsToInt(uf_blockVS7[56].y + uf_blockVS7[56].w);
+PV1i.z = floatBitsToInt(uf_blockVS7[56].x + uf_blockVS7[56].z);
+PV1i.w = floatBitsToInt(-(intBitsToFloat(R125i.y)) + intBitsToFloat(PV0i.y));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(R5i.y));
+// 8
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[54].y) + intBitsToFloat(PV1i.w)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS7[56].z,intBitsToFloat(R4i.w)) + intBitsToFloat(PV1i.z)));
+PV0i.y = R123i.y;
+R4i.z = floatBitsToInt(intBitsToFloat(R127i.x) * intBitsToFloat(PS1i));
+R4i.z = clampFI32(R4i.z);
+R123i.w = floatBitsToInt((mul_nonIEEE(uf_blockVS7[56].w,intBitsToFloat(R2i.z)) + intBitsToFloat(PV1i.x)));
+PV0i.w = R123i.w;
+// 9
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[55].z) + intBitsToFloat(PV0i.y)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R126i.y)),intBitsToFloat(R124i.w)) + intBitsToFloat(PV0i.x)));
+PV1i.y = R123i.y;
+R124i.z = floatBitsToInt(intBitsToFloat(R126i.w) + -(uf_blockVS7[105].w));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R15i.w),uf_blockVS7[55].w) + intBitsToFloat(PV0i.w)));
+PV1i.w = R123i.w;
+// 10
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.x),intBitsToFloat(R127i.z)) + intBitsToFloat(R124i.x)));
+PV0i.x = R123i.x;
+R126i.y = floatBitsToInt(-(uf_blockVS7[104].x) + uf_blockVS7[105].x);
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.w),intBitsToFloat(R125i.z)) + -(intBitsToFloat(PV1i.y))));
+PV0i.w = R123i.w;
+// 11
+R17i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + 0.5);
+R16i.y = floatBitsToInt(intBitsToFloat(PV0i.w) + 0.5);
+PV1i.z = floatBitsToInt(-(uf_blockVS7[104].w) + uf_blockVS7[105].w);
+R124i.w = ((intBitsToFloat(R125i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+R127i.x = ((intBitsToFloat(R124i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PS1i = R127i.x;
+// 12
+R124i.x = floatBitsToInt(-(uf_blockVS7[105].x) + uf_blockVS7[106].x);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.z));
+// 13
+PV1i.x = floatBitsToInt(-(uf_blockVS7[105].w) + uf_blockVS7[106].w);
+PV1i.y = floatBitsToInt(intBitsToFloat(R126i.y) * intBitsToFloat(PS0i));
+R127i.z = floatBitsToInt(intBitsToFloat(R126i.w) + -(uf_blockVS7[106].w));
+PV1i.z = R127i.z;
+// 14
+R126i.y = ((intBitsToFloat(PV1i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.y = R126i.y;
+R125i.z = floatBitsToInt(intBitsToFloat(R126i.w) + -(uf_blockVS7[107].w));
+PV0i.z = R125i.z;
+R127i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.x),intBitsToFloat(PV1i.y)) + uf_blockVS7[104].x));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+// 15
+backupReg0i = R124i.x;
+R124i.x = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R124i.x;
+PV1i.y = floatBitsToInt(-(intBitsToFloat(PV0i.y)) + 1.0);
+PV1i.z = floatBitsToInt(intBitsToFloat(backupReg0i) * intBitsToFloat(PS0i));
+R125i.w = floatBitsToInt(-(uf_blockVS7[106].x) + uf_blockVS7[107].x);
+PS1i = floatBitsToInt(-(intBitsToFloat(R127i.x)) + 1.0);
+// 16
+R126i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.z),intBitsToFloat(PV1i.z)) + uf_blockVS7[105].x));
+R125i.y = floatBitsToInt(intBitsToFloat(R126i.w) + -(uf_blockVS7[108].w));
+PV0i.y = R125i.y;
+PV0i.z = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + 1.0);
+R4i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV1i.y)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.w), intBitsToFloat(PS1i)));
+PS0i = R127i.y;
+// 17
+backupReg0i = R124i.w;
+R125i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R125i.x;
+R5i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PV0i.z)));
+PV1i.z = floatBitsToInt(-(uf_blockVS7[106].w) + uf_blockVS7[107].w);
+R124i.w = floatBitsToInt(-(intBitsToFloat(backupReg0i)) + 1.0);
+// 18
+R127i.x = floatBitsToInt(-(uf_blockVS7[107].x) + uf_blockVS7[108].x);
+PV0i.w = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + 1.0);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.z));
+// 19
+PV1i.x = floatBitsToInt(-(uf_blockVS7[107].w) + uf_blockVS7[108].w);
+PV1i.y = floatBitsToInt(intBitsToFloat(R125i.w) * intBitsToFloat(PS0i));
+R2i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.x), intBitsToFloat(PV0i.w)));
+// 20
+backupReg0i = R127i.z;
+R127i.z = floatBitsToInt(intBitsToFloat(R126i.w) + -(uf_blockVS7[109].w));
+PV0i.z = R127i.z;
+R7i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(PV1i.y)) + uf_blockVS7[106].x));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+// 21
+R124i.x = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R124i.x;
+R1i.y = floatBitsToInt(fract(intBitsToFloat(R1i.w)));
+PV1i.z = floatBitsToInt(intBitsToFloat(R127i.x) * intBitsToFloat(PS0i));
+R125i.w = floatBitsToInt(-(uf_blockVS7[108].x) + uf_blockVS7[109].x);
+R127i.x = floatBitsToInt(intBitsToFloat(R15i.w) * intBitsToFloat(0x42c80000));
+R127i.x = clampFI32(R127i.x);
+PS1i = R127i.x;
+// 22
+R6i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.z),intBitsToFloat(PV1i.z)) + uf_blockVS7[107].x));
+R0i.y = floatBitsToInt(intBitsToFloat(R126i.w) + -(uf_blockVS7[110].w));
+PV0i.y = R0i.y;
+PV0i.z = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + 1.0);
+R3i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.z), intBitsToFloat(PS1i)));
+R1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.y), intBitsToFloat(PS1i)));
+PS0i = R1i.z;
+// 23
+backupReg0i = R125i.x;
+R125i.x = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R125i.x;
+R10i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV0i.z)));
+PV1i.z = floatBitsToInt(-(uf_blockVS7[108].w) + uf_blockVS7[109].w);
+R5i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.w), intBitsToFloat(R127i.x)));
+// 24
+R127i.x = floatBitsToInt(-(uf_blockVS7[109].x) + uf_blockVS7[110].x);
+PV0i.w = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + 1.0);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.z));
+// 25
+PV1i.x = floatBitsToInt(-(uf_blockVS7[109].w) + uf_blockVS7[110].w);
+PV1i.y = floatBitsToInt(intBitsToFloat(R125i.w) * intBitsToFloat(PS0i));
+R5i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.x), intBitsToFloat(PV0i.w)));
+// 26
+PV0i.x = floatBitsToInt(intBitsToFloat(R126i.w) + -(uf_blockVS7[111].w));
+R1i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.y),intBitsToFloat(PV1i.y)) + uf_blockVS7[108].x));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+// 27
+R8i.x = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.x = R8i.x;
+PV1i.z = floatBitsToInt(intBitsToFloat(R127i.x) * intBitsToFloat(PS0i));
+R9i.w = floatBitsToInt(-(uf_blockVS7[110].x) + uf_blockVS7[111].x);
+// 28
+R5i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV1i.z)) + uf_blockVS7[109].x));
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + 1.0);
+PV0i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[104].x, intBitsToFloat(R124i.w)));
+// 29
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.w),intBitsToFloat(R127i.y)) + intBitsToFloat(PV0i.z)));
+PV1i.x = R123i.x;
+R3i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(PV0i.y)));
+PV1i.z = floatBitsToInt(-(uf_blockVS7[110].w) + uf_blockVS7[111].w);
+// 30
+R6i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.x),intBitsToFloat(R4i.w)) + intBitsToFloat(PV1i.x)));
+R1i.x = floatBitsToInt(1.0 / intBitsToFloat(PV1i.z));
+PS0i = R1i.x;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R1i.x;
+R1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.y), uf_blockVS11[5].z));
+R1i.y = floatBitsToInt(intBitsToFloat(R9i.w) * intBitsToFloat(backupReg0i));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.x),uf_blockVS13[24].x) + -(uf_blockVS13[24].y)));
+R123i.z = clampFI32(R123i.z);
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R7i.w),intBitsToFloat(R5i.y)) + intBitsToFloat(R6i.y)));
+PV0i.w = R123i.w;
+// 1
+PV1i.x = floatBitsToInt(-(intBitsToFloat(PV0i.z)) + 1.0);
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.x),intBitsToFloat(R2i.z)) + intBitsToFloat(PV0i.w)));
+PV1i.z = R123i.z;
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.w),intBitsToFloat(R10i.y)) + intBitsToFloat(PV1i.z)));
+PV0i.x = R123i.x;
+tempResultf = log2(intBitsToFloat(PV1i.x));
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS0i = floatBitsToInt(tempResultf);
+// 3
+PV1i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS13[24].w, intBitsToFloat(PS0i)));
+R1i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(R5i.z)) + intBitsToFloat(PV0i.x)));
+// 4
+PS0i = floatBitsToInt(exp2(intBitsToFloat(PV1i.x)));
+// 5
+R2i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PS0i)),uf_blockVS13[25].w) + uf_blockVS13[25].w));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R126i.x = floatBitsToInt(uf_blockVS6[17].x + -(intBitsToFloat(R7i.x)));
+R127i.y = floatBitsToInt(uf_blockVS6[17].y + -(intBitsToFloat(R7i.y)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.y),intBitsToFloat(R1i.y)) + uf_blockVS7[110].x));
+PV0i.w = R123i.w;
+// 1
+R125i.x = floatBitsToInt(uf_blockVS6[17].z + -(intBitsToFloat(R6i.z)));
+PV1i.x = R125i.x;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.w),intBitsToFloat(R3i.y)) + intBitsToFloat(R1i.w)));
+PV1i.z = R123i.z;
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.x) * intBitsToFloat(PV1i.x));
+R5i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS7[111].x,intBitsToFloat(R8i.x)) + intBitsToFloat(PV1i.z)));
+// 3
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R126i.x),intBitsToFloat(R127i.y),intBitsToFloat(PV0i.x),-0.0),vec4(intBitsToFloat(R126i.x),intBitsToFloat(R127i.y),1.0,0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+PS1i = floatBitsToInt(intBitsToFloat(R11i.z) * intBitsToFloat(R11i.w));
+// 4
+R11i.w = floatBitsToInt(-(intBitsToFloat(PS1i)) + 1.0);
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+PS0i = floatBitsToInt(tempResultf);
+// 5
+R8i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.x), intBitsToFloat(PS0i)));
+R3i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PS0i)));
+R6i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(PS0i)));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R8i.x),intBitsToFloat(R3i.y),intBitsToFloat(R6i.z),-0.0),vec4(uf_blockVS13[28].x,uf_blockVS13[28].y,uf_blockVS13[28].z,0.0)));
+tempi.x = floatBitsToInt(intBitsToFloat(tempi.x) / 2.0);
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+PS0i = floatBitsToInt(uf_blockVS13[28].y + 1.0);
+// 1
+R126i.x = floatBitsToInt(intBitsToFloat(PS0i) * 1.5);
+R126i.x = clampFI32(R126i.x);
+R127i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + 0.5);
+PV1i.z = R127i.z;
+PV1i.w = floatBitsToInt(min(uf_blockVS6[17].y, uf_blockVS13[27].z));
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.x),uf_blockVS13[22].x) + -(uf_blockVS13[22].y)));
+R123i.x = clampFI32(R123i.x);
+PV0i.x = R123i.x;
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 1.0);
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R9i.y)) + intBitsToFloat(PV1i.w));
+R123i.w = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0xbc996e30) + intBitsToFloat(0x3d981626)));
+PV0i.w = R123i.w;
+R124i.z = floatBitsToInt((uf_blockVS13[28].y * 1.0 + intBitsToFloat(R9i.x)));
+PS0i = R124i.z;
+// 3
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV0i.w)) + intBitsToFloat(0xbe593484)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS13[27].y,intBitsToFloat(PV0i.z)) + uf_blockVS13[27].x));
+R123i.y = clampFI32(R123i.y);
+PV1i.y = R123i.y;
+R125i.z = floatBitsToInt(intBitsToFloat(R126i.x) * intBitsToFloat(0x41700000));
+PV1i.w = floatBitsToInt(-(intBitsToFloat(PV0i.x)) + 1.0);
+PS1i = floatBitsToInt(sqrt(intBitsToFloat(PV0i.y)));
+// 4
+R8i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), uf_blockVS13[26].w));
+PV0i.y = floatBitsToInt(intBitsToFloat(PS1i) * intBitsToFloat(0x3f22f983));
+R123i.z = floatBitsToInt((intBitsToFloat(R11i.w) * intBitsToFloat(0x3f333333) + intBitsToFloat(0x3e19999a)));
+R123i.z = clampFI32(R123i.z);
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV1i.x)) + intBitsToFloat(0x3fc90da4)));
+PV0i.w = R123i.w;
+tempResultf = log2(intBitsToFloat(PV1i.w));
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS0i = floatBitsToInt(tempResultf);
+// 5
+backupReg0i = R125i.z;
+R9i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.y),-(intBitsToFloat(PV0i.w))) + 1.0));
+PV1i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS13[23].y, intBitsToFloat(PS0i)));
+R125i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS13[23].x, intBitsToFloat(PS0i)));
+PV1i.w = floatBitsToInt(-(intBitsToFloat(PV0i.z)) + 1.0);
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(backupReg0i));
+// 6
+PV0i.x = floatBitsToInt(intBitsToFloat(R124i.z) * intBitsToFloat(PS1i));
+R3i.y = 0;
+R3i.z = ((0.0 >= intBitsToFloat(R4i.z))?int(0xFFFFFFFF):int(0x0));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.w) + intBitsToFloat(0x41080000));
+PS0i = floatBitsToInt(exp2(intBitsToFloat(PV1i.y)));
+PS0i = floatBitsToInt(intBitsToFloat(PS0i) / 2.0);
+// 7
+R3i.x = floatBitsToInt(intBitsToFloat(PV0i.w) * intBitsToFloat(0x3daaaaab));
+R9i.y = floatBitsToInt(intBitsToFloat(PS0i) + 0.5);
+R5i.z = floatBitsToInt(max(intBitsToFloat(PV0i.x), intBitsToFloat(0x3e4ccccd)));
+R1i.w = floatBitsToInt(uf_blockVS6[18].y * intBitsToFloat(0x40a00000));
+R6i.z = floatBitsToInt(exp2(intBitsToFloat(R125i.z)));
+PS1i = R6i.z;
+}
+if( activeMaskStackC[3] == true ) {
+R9i.xyz = floatBitsToInt(texture(textureUnitVS8, intBitsToFloat(R9i.xy)).xyz);
+R0i.xyzw = floatBitsToInt(texture(textureUnitVS13, intBitsToFloat(R3i.xy)).xyzw);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R6i.z;
+PV0i.x = floatBitsToInt(min(intBitsToFloat(R5i.z), 1.0));
+R127i.y = 0;
+R6i.z = 0;
+R123i.w = floatBitsToInt((mul_nonIEEE(-(uf_blockVS13[23].z),intBitsToFloat(backupReg0i)) + uf_blockVS13[23].z));
+R123i.w = clampFI32(R123i.w);
+PV0i.w = R123i.w;
+R3i.x = floatBitsToInt((mul_nonIEEE(uf_blockVS8[3].x,intBitsToFloat(R4i.z)) + 0.0));
+PS0i = R3i.x;
+// 1
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.y), intBitsToFloat(PV0i.x)));
+R9i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.x), intBitsToFloat(PV0i.x)));
+R124i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.z), intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt(-(intBitsToFloat(R1i.x)) + intBitsToFloat(PV0i.w));
+PV1i.w = clampFI32(PV1i.w);
+R4i.x = 0;
+PS1i = R4i.x;
+// 2
+R5i.x = R18i.x;
+R125i.y = PV1i.w;
+R126i.z = PV1i.w;
+R9i.w = ((R3i.z == 0)?(R3i.w):(R127i.y));
+R3i.y = R15i.y;
+PS0i = R3i.y;
+// 3
+R15i.x = ((R3i.z == 0)?(R11i.x):(R11i.x));
+R4i.y = ((R3i.z == 0)?(R5i.w):(R1i.w));
+R4i.z = R14i.z;
+R3i.w = ((R3i.z == 0)?(R5i.y):(R5i.y));
+R10i.y = ((R3i.z == 0)?(R22i.z):(R22i.z));
+PS1i = R10i.y;
+// 4
+R9i.x = ((R3i.z == 0)?(0):(R0i.y));
+R1i.y = ((R3i.z == 0)?(0):(R0i.w));
+R10i.z = ((R3i.z == 0)?(R1i.z):(R6i.z));
+R5i.w = ((R3i.z == 0)?(R3i.x):(R4i.x));
+PV0i.w = R5i.w;
+R127i.w = ((R3i.z == 0)?(0):(R8i.x));
+PS0i = R127i.w;
+// 5
+R126i.x = ((R3i.z == 0)?(0):(R2i.z));
+R126i.y = ((R3i.z == 0)?(0):(R1i.x));
+R125i.z = ((R3i.z == 0)?(0):(R125i.y));
+R10i.w = ((R3i.z == 0)?(0):(PV0i.w));
+R125i.x = ((R3i.z == 0)?(0):(R9i.y));
+PS1i = R125i.x;
+// 6
+R16i.x = ((R3i.z == 0)?(0):(R3i.y));
+R124i.y = ((R3i.z == 0)?(0):(R6i.w));
+R127i.z = ((R3i.z == 0)?(0):(R124i.z));
+R124i.w = ((R3i.z == 0)?(0):(R127i.x));
+R124i.x = ((R3i.z == 0)?(0):(R0i.x));
+PS0i = R124i.x;
+// 7
+R3i.x = ((R3i.z == 0)?(0):(R5i.x));
+R3i.y = ((R3i.z == 0)?(0):(R126i.z));
+R9i.z = ((R3i.z == 0)?(0):(R17i.x));
+R126i.w = ((R3i.z == 0)?(0):(R16i.y));
+R7i.x = ((R3i.z == 0)?(0):(R2i.y));
+PS1i = R7i.x;
+// 8
+R5i.x = ((R3i.z == 0)?(R22i.y):(R5i.y));
+R6i.y = ((R3i.z == 0)?(0):(R13i.w));
+R1i.z = ((R3i.z == 0)?(0):(R0i.z));
+R125i.w = ((R3i.z == 0)?(0):(R2i.x));
+R7i.y = ((R3i.z == 0)?(R22i.x):(R4i.x));
+PS0i = R7i.y;
+// 9
+R6i.x = ((R3i.z == 0)?(0):(R11i.y));
+R5i.y = ((R3i.z == 0)?(0):(R12i.w));
+R13i.z = ((R3i.z == 0)?(0):(R4i.z));
+R7i.w = ((R3i.z == 0)?(0):(R12i.x));
+R13i.x = ((R3i.z == 0)?(0):(R14i.y));
+PS1i = R13i.x;
+// 10
+R4i.x = ((R3i.z == 0)?(0):(R14i.w));
+R8i.y = ((R3i.z == 0)?(0):(R12i.y));
+R5i.z = ((R3i.z == 0)?(0):(R17i.z));
+R4i.w = ((R3i.z == 0)?(0):(R14i.x));
+R10i.x = ((R3i.z == 0)?(0):(R13i.y));
+PS0i = R10i.x;
+// 11
+backupReg0i = R11i.x;
+R11i.x = ((R3i.z == 0)?(R21i.x):(R127i.y));
+R127i.y = ((R3i.z == 0)?(0):(0x3f800000));
+PV1i.y = R127i.y;
+R4i.z = ((R3i.z == 0)?(0):(R8i.z));
+R8i.w = ((R3i.z == 0)?(R21i.w):(backupReg0i));
+R11i.w = ((R3i.z == 0)?(R22i.z):(R22i.z));
+PS1i = R11i.w;
+// 12
+R23i.x = ((PV1i.y == 0)?(R2i.z):(R126i.x));
+R23i.y = ((PV1i.y == 0)?(R8i.x):(R127i.w));
+R23i.z = ((PV1i.y == 0)?(R125i.y):(R125i.z));
+R23i.w = ((PV1i.y == 0)?(R1i.x):(R126i.y));
+R25i.x = ((PV1i.y == 0)?(R6i.w):(R124i.y));
+PS0i = R25i.x;
+// 13
+R24i.x = ((R127i.y == 0)?(R9i.y):(R125i.x));
+R24i.y = ((R127i.y == 0)?(R127i.x):(R124i.w));
+R24i.z = ((R127i.y == 0)?(R124i.z):(R127i.z));
+R124i.w = R18i.x;
+R24i.w = ((R127i.y == 0)?(R126i.z):(R3i.y));
+PS1i = R24i.w;
+// 14
+backupReg0i = R0i.x;
+backupReg1i = R0i.y;
+backupReg2i = R0i.z;
+R0i.x = ((R127i.y == 0)?(backupReg0i):(R124i.x));
+R0i.y = ((R127i.y == 0)?(backupReg1i):(R9i.x));
+R0i.z = ((R127i.y == 0)?(backupReg2i):(R1i.z));
+R127i.w = R14i.z;
+// 15
+backupReg0i = R0i.w;
+backupReg1i = R17i.x;
+R17i.x = ((R127i.y == 0)?(R124i.w):(R3i.x));
+PV1i.x = R17i.x;
+R25i.y = ((R127i.y == 0)?(R2i.y):(R7i.x));
+R0i.w = ((R127i.y == 0)?(backupReg0i):(R1i.y));
+R18i.x = ((R127i.y == 0)?(backupReg1i):(R9i.z));
+PS1i = R18i.x;
+// 16
+R18i.y = ((R127i.y == 0)?(R16i.y):(R126i.w));
+R25i.z = ((R127i.y == 0)?(R2i.x):(R125i.w));
+R25i.w = ((R127i.y == 0)?(R8i.z):(R4i.z));
+R22i.x = ((R127i.y == 0)?(R5i.w):(R7i.y));
+PS0i = R22i.x;
+// 17
+R19i.x = ((R127i.y == 0)?(R11i.y):(R6i.x));
+R22i.y = ((R127i.y == 0)?(R3i.w):(R5i.x));
+R22i.z = ((R127i.y == 0)?(R10i.y):(R11i.w));
+R123i.w = ((R3i.z == 0)?(0):(R7i.z));
+PV1i.w = R123i.w;
+R124i.x = ((R3i.z == 0)?(R21i.z):(R1i.w));
+PS1i = R124i.x;
+// 18
+R20i.x = ((R127i.y == 0)?(R12i.w):(R5i.y));
+R123i.y = ((R3i.z == 0)?(0):(R11i.z));
+PV0i.y = R123i.y;
+R26i.x = ((R127i.y == 0)?(R7i.z):(PV1i.w));
+PS0i = R26i.x;
+// 19
+R21i.x = ((R127i.y == 0)?(R9i.w):(R11i.x));
+R19i.y = ((R127i.y == 0)?(R11i.z):(PV0i.y));
+R19i.z = ((R127i.y == 0)?(R13i.w):(R6i.y));
+R19i.w = ((R127i.y == 0)?(R12i.x):(R7i.w));
+R18i.z = ((R127i.y == 0)?(R17i.z):(R5i.z));
+PS1i = R18i.z;
+// 20
+R26i.y = ((R127i.y == 0)?(R12i.y):(R8i.y));
+// 21
+R123i.y = ((R3i.z == 0)?(0):(R12i.z));
+PV1i.y = R123i.y;
+R26i.z = ((R127i.y == 0)?(R13i.y):(R10i.x));
+R26i.w = ((R127i.y == 0)?(R14i.w):(R4i.x));
+// 22
+R123i.x = ((R3i.z == 0)?(R21i.y):(R6i.z));
+PV0i.x = R123i.x;
+R20i.y = ((R127i.y == 0)?(R12i.z):(PV1i.y));
+R20i.z = ((R127i.y == 0)?(R14i.y):(R13i.x));
+R20i.w = ((R127i.y == 0)?(R14i.x):(R4i.w));
+// 23
+PV1i.x = R15i.y;
+R21i.y = ((R127i.y == 0)?(R10i.z):(PV0i.x));
+R21i.z = ((R127i.y == 0)?(R4i.y):(R124i.x));
+R21i.w = ((R127i.y == 0)?(R15i.x):(R8i.w));
+// 24
+R17i.y = ((R127i.y == 0)?(PV1i.x):(R16i.x));
+R17i.z = ((R127i.y == 0)?(R127i.w):(R13i.z));
+R17i.w = ((R127i.y == 0)?(R10i.w):(R10i.w));
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+// export
+gl_Position = vec4(intBitsToFloat(R21i.x), intBitsToFloat(R21i.y), intBitsToFloat(R21i.z), intBitsToFloat(R21i.w));
+// export
+passParameterSem0 = vec4(intBitsToFloat(R26i.x), intBitsToFloat(R26i.y), intBitsToFloat(R26i.z), intBitsToFloat(R26i.w));
+// export
+passParameterSem1 = vec4(intBitsToFloat(R20i.x), intBitsToFloat(R20i.y), intBitsToFloat(R20i.z), intBitsToFloat(R20i.w));
+// export
+passParameterSem3 = vec4(intBitsToFloat(R19i.x), intBitsToFloat(R19i.y), intBitsToFloat(R19i.z), intBitsToFloat(R19i.w));
+// export
+passParameterSem8 = vec4(intBitsToFloat(R25i.x), intBitsToFloat(R25i.y), intBitsToFloat(R25i.z), intBitsToFloat(R25i.w));
+// export
+passParameterSem11 = vec4(intBitsToFloat(R17i.x), intBitsToFloat(R17i.y), intBitsToFloat(R17i.z), intBitsToFloat(R17i.w));
+// export
+passParameterSem14 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+// export
+passParameterSem15 = vec4(intBitsToFloat(R24i.x), intBitsToFloat(R24i.y), intBitsToFloat(R24i.z), intBitsToFloat(R24i.w));
+// export
+passParameterSem16 = vec4(intBitsToFloat(R23i.x), intBitsToFloat(R23i.y), intBitsToFloat(R23i.z), intBitsToFloat(R23i.w));
+// export
+passParameterSem4 = vec4(intBitsToFloat(R22i.x), intBitsToFloat(R22i.y), intBitsToFloat(R22i.z), intBitsToFloat(R22i.z));
+// export
+passParameterSem9 = vec4(intBitsToFloat(R18i.x), intBitsToFloat(R18i.y), intBitsToFloat(R18i.z), intBitsToFloat(R18i.z));
+}

--- a/Workaround/BreathOfTheWild_BombAsh/rules.txt
+++ b/Workaround/BreathOfTheWild_BombAsh/rules.txt
@@ -1,0 +1,8 @@
+[Definition]
+titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
+name = "The Legend of Zelda: Breath of the Wild - Bomb Arrow Smoke Fix"
+version = 2
+
+# A quick found by Xalphenos and Rajkosto
+# Partially fix thin paper look explosion smoke on nvdia when using AccurateShaderMul = true
+# Shaders dumped from Cemu 1.10.0f and BotW 1.3.1


### PR DESCRIPTION
Found by Xalphenos and Rajkosto on Discord.
Partially fix thin paper look explosion smoke **on Nvdia** when using **AccurateShaderMul = true**, by using the ones from AccurateShaderMul = min
Shaders dumped from Cemu 1.10.0f and BotW 1.3.1
From Xalphenos, true: ![](http://i.imgur.com/tHAOqGW.jpg)
From Forkinator, min: ![](https://cdn.discordapp.com/attachments/292733452590120961/366420061587767298/fix.jpg)