### PR TITLE
splatoon missing bloom

### DIFF
--- a/Enthusiast/Splatoon_2880p/rules.txt
+++ b/Enthusiast/Splatoon_2880p/rules.txt
@@ -74,3 +74,11 @@ width = 848
 height = 480
 overwriteWidth = 2560
 overwriteHeight = 1440
+
+
+[TextureRedefine] # a bloom mip
+width = 160
+height = 90
+formats = 0x816
+overwriteWidth = 640
+overwriteHeight = 360

--- a/Enthusiast/Splatoon_4320p/rules.txt
+++ b/Enthusiast/Splatoon_4320p/rules.txt
@@ -74,3 +74,11 @@ width = 848
 height = 480
 overwriteWidth = 2560
 overwriteHeight = 1440
+
+
+[TextureRedefine] # a bloom mip
+width = 160
+height = 90
+formats = 0x816
+overwriteWidth = 960
+overwriteHeight = 540

--- a/Enthusiast/Splatoon_5760p/rules.txt
+++ b/Enthusiast/Splatoon_5760p/rules.txt
@@ -74,3 +74,11 @@ width = 848
 height = 480
 overwriteWidth = 2560
 overwriteHeight = 1440
+
+
+[TextureRedefine] # a bloom mip
+width = 160
+height = 90
+formats = 0x816
+overwriteWidth = 1280
+overwriteHeight = 720

--- a/Quality/Splatoon_1080p/rules.txt
+++ b/Quality/Splatoon_1080p/rules.txt
@@ -66,3 +66,11 @@ width = 424
 height = 240
 overwriteWidth = 960
 overwriteHeight = 540
+
+
+[TextureRedefine] # a bloom mip
+width = 160
+height = 90
+formats = 0x816
+overwriteWidth = 240
+overwriteHeight = 135

--- a/Quality/Splatoon_1080pUW/rules.txt
+++ b/Quality/Splatoon_1080pUW/rules.txt
@@ -66,3 +66,11 @@ width = 424
 height = 240
 overwriteWidth = 1280
 overwriteHeight = 540
+
+
+[TextureRedefine] # a bloom mip
+width = 160
+height = 90
+formats = 0x816
+overwriteWidth = 320
+overwriteHeight = 135

--- a/Quality/Splatoon_1440p/rules.txt
+++ b/Quality/Splatoon_1440p/rules.txt
@@ -66,3 +66,11 @@ width = 424
 height = 240
 overwriteWidth = 1280
 overwriteHeight = 720
+
+
+[TextureRedefine] # a bloom mip
+width = 160
+height = 90
+formats = 0x816
+overwriteWidth = 320
+overwriteHeight = 180

--- a/Quality/Splatoon_1800p/rules.txt
+++ b/Quality/Splatoon_1800p/rules.txt
@@ -66,3 +66,11 @@ width = 424
 height = 240
 overwriteWidth = 1600
 overwriteHeight = 900
+
+
+[TextureRedefine] # a bloom mip
+width = 160
+height = 90
+formats = 0x816
+overwriteWidth = 400
+overwriteHeight = 225

--- a/Quality/Splatoon_2160p/rules.txt
+++ b/Quality/Splatoon_2160p/rules.txt
@@ -75,3 +75,11 @@ width = 424
 height = 240
 overwriteWidth = 1920
 overwriteHeight = 1080
+
+
+[TextureRedefine] # a bloom mip
+width = 160
+height = 90
+formats = 0x816
+overwriteWidth = 480
+overwriteHeight = 270

--- a/Workaround/BreathOfTheWild_BombAsh/2938a1b3abfdfe49_0000000000000000_vs.txt
+++ b/Workaround/BreathOfTheWild_BombAsh/2938a1b3abfdfe49_0000000000000000_vs.txt
@@ -1,0 +1,2575 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_shading_language_packing : enable
+// shader 2938a1b3abfdfe49
+layout(binding = 6, std140) uniform uniformBlockVS6
+{
+vec4 uf_blockVS6[1024];
+};
+
+layout(binding = 7, std140) uniform uniformBlockVS7
+{
+vec4 uf_blockVS7[1024];
+};
+
+layout(binding = 8, std140) uniform uniformBlockVS8
+{
+vec4 uf_blockVS8[1024];
+};
+
+layout(binding = 11, std140) uniform uniformBlockVS11
+{
+vec4 uf_blockVS11[1024];
+};
+
+layout(binding = 13, std140) uniform uniformBlockVS13
+{
+vec4 uf_blockVS13[1024];
+};
+
+uniform vec2 uf_windowSpaceToClipSpaceTransform;
+uniform float uf_alphaTestRef;
+layout(binding = 40) uniform sampler2D textureUnitVS8;// Tex8 addr 0x3da26000 res 256x256x1 dim 1 tm: 4 format 0820 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler26 ClampX/Y/Z: 2 2 2 border: 1
+layout(binding = 45) uniform sampler2D textureUnitVS13;// Tex13 addr 0x3db8b000 res 12x1x1 dim 1 tm: 2 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler31 ClampX/Y/Z: 2 2 2 border: 1
+layout(location = 0) in uvec4 attrDataSem0;
+layout(location = 1) in uvec4 attrDataSem1;
+layout(location = 2) in uvec4 attrDataSem2;
+layout(location = 3) in uvec4 attrDataSem3;
+layout(location = 4) in uvec4 attrDataSem4;
+layout(location = 5) in uvec4 attrDataSem5;
+layout(location = 6) in uvec4 attrDataSem6;
+layout(location = 7) in uvec4 attrDataSem7;
+layout(location = 8) in uvec4 attrDataSem8;
+layout(location = 9) in uvec4 attrDataSem9;
+layout(location = 10) in uvec4 attrDataSem10;
+layout(location = 11) in uvec4 attrDataSem11;
+layout(location = 12) in uvec4 attrDataSem12;
+layout(location = 13) in uvec4 attrDataSem13;
+layout(location = 14) in uvec4 attrDataSem14;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+	float gl_PointSize;
+};
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 2) out vec4 passParameterSem3;
+layout(location = 4) out vec4 passParameterSem5;
+layout(location = 5) out vec4 passParameterSem8;
+layout(location = 7) out vec4 passParameterSem11;
+layout(location = 8) out vec4 passParameterSem14;
+layout(location = 9) out vec4 passParameterSem15;
+layout(location = 10) out vec4 passParameterSem16;
+layout(location = 3) out vec4 passParameterSem4;
+layout(location = 6) out vec4 passParameterSem9;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ return min(a*b,min(abs(a)*3.40282347E+38F,abs(b)*3.40282347E+38F)); }
+void main()
+{
+ivec4 R0i = ivec4(0);
+ivec4 R1i = ivec4(0);
+ivec4 R2i = ivec4(0);
+ivec4 R3i = ivec4(0);
+ivec4 R4i = ivec4(0);
+ivec4 R5i = ivec4(0);
+ivec4 R6i = ivec4(0);
+ivec4 R7i = ivec4(0);
+ivec4 R8i = ivec4(0);
+ivec4 R9i = ivec4(0);
+ivec4 R10i = ivec4(0);
+ivec4 R11i = ivec4(0);
+ivec4 R12i = ivec4(0);
+ivec4 R13i = ivec4(0);
+ivec4 R14i = ivec4(0);
+ivec4 R15i = ivec4(0);
+ivec4 R16i = ivec4(0);
+ivec4 R17i = ivec4(0);
+ivec4 R18i = ivec4(0);
+ivec4 R19i = ivec4(0);
+ivec4 R20i = ivec4(0);
+ivec4 R21i = ivec4(0);
+ivec4 R22i = ivec4(0);
+ivec4 R23i = ivec4(0);
+ivec4 R24i = ivec4(0);
+ivec4 R25i = ivec4(0);
+ivec4 R123i = ivec4(0);
+ivec4 R124i = ivec4(0);
+ivec4 R125i = ivec4(0);
+ivec4 R126i = ivec4(0);
+ivec4 R127i = ivec4(0);
+uvec4 attrDecoder;
+int backupReg0i, backupReg1i, backupReg2i, backupReg3i, backupReg4i;
+ivec4 PV0i = ivec4(0), PV1i = ivec4(0);
+int PS0i = 0, PS1i = 0;
+ivec4 tempi = ivec4(0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+bool activeMaskStack[3];
+bool activeMaskStackC[4];
+activeMaskStack[0] = false;
+activeMaskStack[1] = false;
+activeMaskStackC[0] = false;
+activeMaskStackC[1] = false;
+activeMaskStackC[2] = false;
+activeMaskStack[0] = true;
+activeMaskStackC[0] = true;
+activeMaskStackC[1] = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0i = ivec4(gl_VertexID, 0, 0, gl_InstanceID);
+attrDecoder = attrDataSem9;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R9i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder.xyz = attrDataSem8.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R8i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), floatBitsToInt(1.0));
+attrDecoder = attrDataSem13;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R12i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem3;
+R4i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem6;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R6i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem7;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R7i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem11;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R11i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem10;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R10i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem5;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R5i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem0;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R1i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem1;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R2i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+attrDecoder = attrDataSem2;
+attrDecoder = (attrDecoder>>24)|((attrDecoder>>8)&0xFF00)|((attrDecoder<<8)&0xFF0000)|((attrDecoder<<24));
+R3i = ivec4(int(attrDecoder.x), int(attrDecoder.y), int(attrDecoder.z), int(attrDecoder.w));
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+R17i.z = floatBitsToInt(-(intBitsToFloat(R12i.y)) + 1.0);
+R5i.w = 0;
+R8i.w = floatBitsToInt(1.0);
+PS0i = R8i.w;
+// 1
+R12i.w = floatBitsToInt(-(intBitsToFloat(R7i.w)) + uf_blockVS8[2].x);
+R16i.w = floatBitsToInt(-(intBitsToFloat(R12i.x)) + 1.0);
+PS1i = R16i.w;
+// 2
+predResult = (0.0 > intBitsToFloat(R12i.w));
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+// 0
+R19i.x = 0;
+R19i.y = 0;
+R19i.z = floatBitsToInt(uf_blockVS6[18].y * intBitsToFloat(0x40a00000));
+R20i.x = 0;
+PS0i = R20i.x;
+// 1
+R7i.w = R8i.w;
+}
+activeMaskStack[1] = activeMaskStack[1] == false;
+activeMaskStackC[2] = activeMaskStack[1] == true && activeMaskStackC[1] == true;
+if( activeMaskStackC[2] == true ) {
+// 0
+R7i.w = R5i.w;
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+if( activeMaskStackC[1] == true ) {
+activeMaskStack[1] = activeMaskStack[0];
+activeMaskStackC[2] = activeMaskStackC[1];
+// 0
+predResult = (R7i.w == 0);
+activeMaskStack[1] = predResult;
+activeMaskStackC[2] = predResult == true && activeMaskStackC[1] == true;
+}
+else {
+activeMaskStack[1] = false;
+activeMaskStackC[2] = false;
+}
+if( activeMaskStackC[2] == true ) {
+activeMaskStack[2] = activeMaskStack[1];
+activeMaskStackC[3] = activeMaskStackC[2];
+// 0
+PS0i = int(intBitsToFloat(R6i.w));
+// 1
+R7i.x = floatBitsToInt(float(PS0i));
+PS1i = R7i.x;
+// 2
+predResult = (intBitsToFloat(R12i.w) >= intBitsToFloat(R7i.x));
+activeMaskStack[2] = predResult;
+activeMaskStackC[3] = predResult == true && activeMaskStackC[2] == true;
+}
+else {
+activeMaskStack[2] = false;
+activeMaskStackC[3] = false;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R19i.x = 0;
+R19i.y = 0;
+R19i.z = floatBitsToInt(uf_blockVS6[18].y * intBitsToFloat(0x40a00000));
+R20i.x = 0;
+PS0i = R20i.x;
+// 1
+R5i.w = R8i.w;
+}
+activeMaskStackC[2] = activeMaskStack[1] == true && activeMaskStackC[1] == true;
+if( activeMaskStackC[2] == true ) {
+activeMaskStack[2] = activeMaskStack[1];
+activeMaskStackC[3] = activeMaskStackC[2];
+// 0
+predResult = (R5i.w == 0);
+activeMaskStack[2] = predResult;
+activeMaskStackC[3] = predResult == true && activeMaskStackC[2] == true;
+}
+else {
+activeMaskStack[2] = false;
+activeMaskStackC[3] = false;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt((0.0 > uf_blockVS7[9].x)?1.0:0.0);
+PV0i.y = floatBitsToInt((uf_blockVS7[9].x > 0.0)?1.0:0.0);
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R10i.x), uf_blockVS7[10].y));
+PV0i.w = floatBitsToInt(max(intBitsToFloat(R10i.x), 0.0));
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[9].x);
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(R12i.w) * intBitsToFloat(PS0i));
+R127i.y = floatBitsToInt(-(uf_blockVS7[96].x) + uf_blockVS7[97].x);
+PV1i.z = floatBitsToInt(min(intBitsToFloat(PV0i.w), 0.0));
+R127i.w = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.x)));
+PV1i.w = R127i.w;
+R6i.y = floatBitsToInt(1.0 / intBitsToFloat(R7i.x));
+PS1i = R6i.y;
+// 2
+R7i.x = floatBitsToInt(intBitsToFloat(R11i.x) + intBitsToFloat(PV1i.z));
+R7i.y = floatBitsToInt(intBitsToFloat(R12i.w) * intBitsToFloat(PS1i));
+PV0i.y = R7i.y;
+PV0i.z = floatBitsToInt(-(intBitsToFloat(PV1i.w)) + 1.0);
+PV0i.w = floatBitsToInt(intBitsToFloat(R127i.z) + intBitsToFloat(PV1i.x));
+R126i.y = floatBitsToInt(-(uf_blockVS7[96].y) + uf_blockVS7[97].y);
+PS0i = R126i.y;
+// 3
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.y), intBitsToFloat(PV0i.z)));
+R125i.y = floatBitsToInt(-(uf_blockVS7[96].z) + uf_blockVS7[97].z);
+PV1i.z = floatBitsToInt(fract(intBitsToFloat(PV0i.w)));
+PV1i.w = floatBitsToInt(-(uf_blockVS7[96].w) + uf_blockVS7[97].w);
+// 4
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PV1i.z)));
+R126i.z = floatBitsToInt(-(uf_blockVS7[97].y) + uf_blockVS7[98].y);
+R125i.w = floatBitsToInt(-(uf_blockVS7[97].x) + uf_blockVS7[98].x);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.w));
+// 5
+backupReg0i = R127i.y;
+R125i.x = floatBitsToInt(intBitsToFloat(R127i.x) + intBitsToFloat(PV0i.y));
+PV1i.x = R125i.x;
+R127i.y = floatBitsToInt(intBitsToFloat(backupReg0i) * intBitsToFloat(PS0i));
+R127i.z = floatBitsToInt(intBitsToFloat(R126i.y) * intBitsToFloat(PS0i));
+R127i.w = floatBitsToInt(intBitsToFloat(R125i.y) * intBitsToFloat(PS0i));
+R126i.y = floatBitsToInt(-(uf_blockVS7[97].z) + uf_blockVS7[98].z);
+PS1i = R126i.y;
+// 6
+R127i.x = floatBitsToInt(intBitsToFloat(PV1i.x) + -(uf_blockVS7[97].w));
+R126i.w = floatBitsToInt(intBitsToFloat(PV1i.x) + -(uf_blockVS7[96].w));
+PV0i.w = R126i.w;
+// 7
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(R127i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(R127i.z)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.w), intBitsToFloat(R127i.y)));
+PV1i.w = floatBitsToInt(-(uf_blockVS7[97].w) + uf_blockVS7[98].w);
+R127i.y = floatBitsToInt(intBitsToFloat(R125i.x) + -(uf_blockVS7[98].w));
+PS1i = R127i.y;
+// 8
+R0i.x = ((intBitsToFloat(R126i.w) >= 0.0)?(floatBitsToInt(1.0)):(0));
+R124i.y = floatBitsToInt(uf_blockVS7[96].z + intBitsToFloat(PV1i.x));
+R127i.z = floatBitsToInt(uf_blockVS7[96].y + intBitsToFloat(PV1i.y));
+R124i.w = floatBitsToInt(uf_blockVS7[96].x + intBitsToFloat(PV1i.z));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.w));
+// 9
+PV1i.x = floatBitsToInt(intBitsToFloat(R126i.y) * intBitsToFloat(PS0i));
+PV1i.y = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(PS0i));
+PV1i.z = floatBitsToInt(intBitsToFloat(R125i.w) * intBitsToFloat(PS0i));
+R125i.w = floatBitsToInt(-(uf_blockVS7[98].x) + uf_blockVS7[99].x);
+R126i.w = floatBitsToInt(-(uf_blockVS7[98].y) + uf_blockVS7[99].y);
+PS1i = R126i.w;
+// 10
+R126i.x = floatBitsToInt(-(uf_blockVS7[98].z) + uf_blockVS7[99].z);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV1i.x)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV1i.z)));
+PS0i = floatBitsToInt(-(uf_blockVS7[98].w) + uf_blockVS7[99].w);
+// 11
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(uf_blockVS7[97].x + intBitsToFloat(PV0i.w));
+R125i.y = ((intBitsToFloat(backupReg0i) >= 0.0)?(floatBitsToInt(1.0)):(0));
+R126i.z = floatBitsToInt(uf_blockVS7[97].z + intBitsToFloat(PV0i.y));
+R127i.w = floatBitsToInt(uf_blockVS7[97].y + intBitsToFloat(PV0i.z));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 12
+backupReg0i = R126i.x;
+R126i.x = ((intBitsToFloat(R127i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.x = R126i.x;
+PV0i.y = floatBitsToInt(intBitsToFloat(backupReg0i) * intBitsToFloat(PS1i));
+PV0i.z = floatBitsToInt(intBitsToFloat(R126i.w) * intBitsToFloat(PS1i));
+PV0i.w = floatBitsToInt(intBitsToFloat(R125i.w) * intBitsToFloat(PS1i));
+PS0i = floatBitsToInt(intBitsToFloat(R125i.x) + -(uf_blockVS7[99].w));
+// 13
+backupReg0i = R127i.y;
+backupReg0i = R127i.y;
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV0i.w)));
+R127i.y = ((intBitsToFloat(PS0i) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.y = R127i.y;
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV0i.y)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV0i.z)));
+PS1i = floatBitsToInt(-(intBitsToFloat(PV0i.x)) + 1.0);
+// 14
+R125i.x = floatBitsToInt(uf_blockVS7[98].y + intBitsToFloat(PV1i.w));
+R126i.y = floatBitsToInt(uf_blockVS7[98].x + intBitsToFloat(PV1i.x));
+PV0i.z = floatBitsToInt(-(intBitsToFloat(PV1i.y)) + 1.0);
+R126i.w = floatBitsToInt(uf_blockVS7[98].z + intBitsToFloat(PV1i.z));
+R124i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.y), intBitsToFloat(PS1i)));
+PS0i = R124i.x;
+// 15
+R6i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[99].x, intBitsToFloat(R127i.y)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.x), intBitsToFloat(PV0i.z)));
+R0i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[99].y, intBitsToFloat(R127i.y)));
+R5i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[99].z, intBitsToFloat(R127i.y)));
+R125i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS0i)));
+PS1i = R125i.w;
+// 16
+backupReg0i = R124i.x;
+backupReg0i = R124i.x;
+R124i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PV1i.y)));
+R127i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(backupReg0i)));
+R124i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.w), intBitsToFloat(PV1i.y)));
+R0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.x), intBitsToFloat(PV1i.y)));
+R0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.z), intBitsToFloat(backupReg0i)));
+PS0i = R0i.y;
+// 17
+backupReg0i = R0i.x;
+PV1i.x = floatBitsToInt(-(intBitsToFloat(R125i.y)) + 1.0);
+R125i.y = floatBitsToInt(intBitsToFloat(R10i.x) + intBitsToFloat(R10i.y));
+R125i.z = floatBitsToInt(intBitsToFloat(R10i.y) + intBitsToFloat(R10i.z));
+R126i.w = floatBitsToInt(-(intBitsToFloat(backupReg0i)) + 1.0);
+R6i.w = 0x3f800000;
+PS1i = R6i.w;
+// 18
+R13i.x = floatBitsToInt(dot(vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.y),intBitsToFloat(R1i.z),intBitsToFloat(R1i.w)),vec4(intBitsToFloat(R4i.x),intBitsToFloat(R4i.y),intBitsToFloat(R4i.z),intBitsToFloat(PS1i))));
+PV0i.x = R13i.x;
+PV0i.y = R13i.x;
+PV0i.z = R13i.x;
+PV0i.w = R13i.x;
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.x), intBitsToFloat(PV1i.x)));
+PS0i = R127i.w;
+// 19
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R2i.x),intBitsToFloat(R2i.y),intBitsToFloat(R2i.z),intBitsToFloat(R2i.w)),vec4(intBitsToFloat(R4i.x),intBitsToFloat(R4i.y),intBitsToFloat(R4i.z),intBitsToFloat(R6i.w))));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R12i.z = tempi.x;
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.w), intBitsToFloat(PS0i)));
+PS1i = R126i.z;
+// 20
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R3i.y),intBitsToFloat(R3i.z),intBitsToFloat(R3i.w)),vec4(intBitsToFloat(R4i.x),intBitsToFloat(R4i.y),intBitsToFloat(R4i.z),intBitsToFloat(R6i.w))));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R1i.y = tempi.x;
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(R127i.w)));
+PS0i = R126i.y;
+// 21
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.y), intBitsToFloat(R127i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[96].y, intBitsToFloat(R126i.w)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[96].x, intBitsToFloat(R126i.w)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[96].z, intBitsToFloat(R126i.w)));
+R125i.x = floatBitsToInt(intBitsToFloat(R125i.y) * 0.5);
+PS1i = R125i.x;
+// 22
+R127i.x = floatBitsToInt(intBitsToFloat(R125i.z) * 0.5);
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.x) + intBitsToFloat(PV1i.w));
+PV0i.z = floatBitsToInt(intBitsToFloat(R126i.y) + intBitsToFloat(PV1i.y));
+PV0i.w = floatBitsToInt(intBitsToFloat(R126i.z) + intBitsToFloat(PV1i.z));
+PS0i = floatBitsToInt(intBitsToFloat(R10i.x) + intBitsToFloat(R10i.z));
+// 23
+backupReg0i = R0i.y;
+PV1i.x = floatBitsToInt(intBitsToFloat(R125i.w) + intBitsToFloat(PV0i.w));
+PV1i.y = floatBitsToInt(intBitsToFloat(PS0i) * 0.5);
+PV1i.z = floatBitsToInt(intBitsToFloat(backupReg0i) + intBitsToFloat(PV0i.y));
+PV1i.w = floatBitsToInt(intBitsToFloat(R127i.y) + intBitsToFloat(PV0i.z));
+R3i.z = floatBitsToInt(intBitsToFloat(R125i.x) + -(0.5));
+R3i.z = floatBitsToInt(intBitsToFloat(R3i.z) * 2.0);
+PS1i = R3i.z;
+// 24
+R3i.x = floatBitsToInt(intBitsToFloat(R0i.w) + intBitsToFloat(PV1i.w));
+R0i.y = floatBitsToInt(intBitsToFloat(R124i.x) + intBitsToFloat(PV1i.x));
+R2i.z = floatBitsToInt(intBitsToFloat(R127i.x) + -(0.5));
+R2i.z = floatBitsToInt(intBitsToFloat(R2i.z) * 2.0);
+R0i.w = floatBitsToInt(intBitsToFloat(R124i.z) + intBitsToFloat(PV1i.z));
+R3i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + -(0.5));
+R3i.w = floatBitsToInt(intBitsToFloat(R3i.w) * 2.0);
+PS0i = R3i.w;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R0i.y;
+PV0i.x = floatBitsToInt(intBitsToFloat(R5i.w) + intBitsToFloat(R0i.w));
+PV0i.y = floatBitsToInt(intBitsToFloat(R0i.z) + intBitsToFloat(R3i.x));
+PV0i.z = floatBitsToInt(intBitsToFloat(R6i.x) + intBitsToFloat(backupReg0i));
+R127i.w = floatBitsToInt(intBitsToFloat(R10i.x) + -(0.5));
+R124i.z = floatBitsToInt(intBitsToFloat(R10i.y) + -(0.5));
+PS0i = R124i.z;
+// 1
+R11i.x = floatBitsToInt(intBitsToFloat(R10i.z) + -(0.5));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.z), intBitsToFloat(PV0i.x)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.y), intBitsToFloat(PV0i.y)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.x), intBitsToFloat(PV0i.z)));
+R125i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), uf_blockVS7[115].x));
+PS1i = R125i.w;
+// 2
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), uf_blockVS8[3].y));
+R2i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.y), uf_blockVS8[3].w));
+R3i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.z), uf_blockVS8[3].z));
+R0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), uf_blockVS8[3].y));
+PS0i = R10i.y;
+PS0i = floatBitsToInt(intBitsToFloat(PS0i) * 2.0);
+// 3
+R6i.x = floatBitsToInt(intBitsToFloat(R125i.w) + uf_blockVS7[114].x);
+PV1i.y = floatBitsToInt(floor(intBitsToFloat(PS0i)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.z), uf_blockVS7[115].y));
+PV1i.w = R10i.z;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV1i.w) * 2.0);
+R127i.y = R10i.x;
+R127i.y = floatBitsToInt(intBitsToFloat(R127i.y) * 2.0);
+PS1i = R127i.y;
+// 4
+PV0i.x = floatBitsToInt((intBitsToFloat(PV1i.y) > 0.0)?1.0:0.0);
+R0i.y = floatBitsToInt(uf_blockVS7[114].y + intBitsToFloat(PV1i.z));
+PV0i.z = floatBitsToInt((0.0 > intBitsToFloat(PV1i.y))?1.0:0.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), uf_blockVS7[115].z));
+PS0i = floatBitsToInt(floor(intBitsToFloat(PV1i.w)));
+// 5
+R3i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.z)));
+R3i.y = floatBitsToInt(uf_blockVS7[114].z + intBitsToFloat(PV0i.w));
+PV1i.z = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.w = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PS1i = floatBitsToInt(floor(intBitsToFloat(R127i.y)));
+// 6
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.y = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R2i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + -(intBitsToFloat(PV1i.z)));
+R3i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), uf_blockVS7[113].x));
+R2i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), uf_blockVS7[113].y));
+PS0i = R2i.x;
+// 7
+R11i.y = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.y)));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R127i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x00020000;
+PV0i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00010000;
+R127i.w = floatBitsToInt(uf_blockVS7[5].x) & 0x00040000;
+// 1
+PS1i = floatBitsToInt(float(PV0i.z));
+// 2
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R11i.x), uf_blockVS7[113].z));
+PV0i.w = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PS0i = floatBitsToInt(float(R127i.y));
+// 3
+PV1i.x = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PV1i.y = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.x)));
+PS1i = floatBitsToInt(float(R127i.w));
+// 4
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.x) + -(intBitsToFloat(PV1i.y)));
+PV0i.z = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+R127i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R127i.y;
+// 5
+PV1i.x = 0 - PS0i;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.z) + -(intBitsToFloat(PV0i.x)));
+R127i.w = int(intBitsToFloat(PV0i.y));
+PS1i = R127i.w;
+// 6
+PV0i.x = max(R127i.y, PV1i.x);
+PV0i.y = 0 - PS1i;
+R125i.w = ((uf_blockVS7[114].w == 1.0)?int(0xFFFFFFFF):int(0x0));
+R127i.x = int(intBitsToFloat(PV1i.w));
+PS0i = R127i.x;
+// 7
+PV1i.x = 0 - PS0i;
+PV1i.z = max(R127i.w, PV0i.y);
+PS1i = floatBitsToInt(float(PV0i.x));
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) * 2.0);
+// 8
+PV0i.y = max(R127i.x, PV1i.x);
+R124i.z = floatBitsToInt(-(uf_blockVS7[114].w) + 1.0);
+PV0i.w = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(PS1i)), intBitsToFloat(R3i.x)));
+PS0i = floatBitsToInt(float(PV1i.z));
+PS0i = floatBitsToInt(intBitsToFloat(PS0i) * 2.0);
+// 9
+PV1i.x = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(PS0i)), intBitsToFloat(R2i.z)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.x), intBitsToFloat(PV0i.w)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.x), intBitsToFloat(PV0i.w)));
+PS1i = floatBitsToInt(float(PV0i.y));
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) * 2.0);
+// 10
+backupReg0i = R0i.y;
+PV0i.x = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(PS1i)), intBitsToFloat(R11i.y)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PV1i.x)));
+R126i.z = floatBitsToInt(intBitsToFloat(R6i.x) + intBitsToFloat(PV1i.y));
+PV0i.w = floatBitsToInt(intBitsToFloat(R5i.x) + intBitsToFloat(PV1i.z));
+PS0i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.y), intBitsToFloat(PV1i.x)));
+// 11
+PV1i.x = floatBitsToInt(intBitsToFloat(R5i.y) + intBitsToFloat(PS0i));
+R127i.y = floatBitsToInt(intBitsToFloat(R0i.y) + intBitsToFloat(PV0i.y));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.y), intBitsToFloat(PV0i.x)));
+R126i.w = floatBitsToInt(intBitsToFloat(PV0i.w) + intBitsToFloat(R3i.w));
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.z), intBitsToFloat(PV0i.x)));
+// 12
+R127i.x = floatBitsToInt(intBitsToFloat(PV1i.x) + intBitsToFloat(R2i.x));
+PV0i.z = floatBitsToInt(intBitsToFloat(R5i.z) + intBitsToFloat(PS1i));
+R127i.w = floatBitsToInt(intBitsToFloat(R3i.y) + intBitsToFloat(PV1i.z));
+tempResultf = log2(uf_blockVS7[114].w);
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS0i = floatBitsToInt(tempResultf);
+// 13
+backupReg0i = R0i.x;
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), uf_blockVS7[13].z));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.w), intBitsToFloat(PS0i)));
+R124i.w = floatBitsToInt(intBitsToFloat(PV0i.z) + intBitsToFloat(R126i.y));
+R126i.y = floatBitsToInt(1.0 / intBitsToFloat(R124i.z));
+PS1i = R126i.y;
+// 14
+PS0i = floatBitsToInt(exp2(intBitsToFloat(PV1i.z)));
+// 15
+PV1i.x = floatBitsToInt(-(intBitsToFloat(PS0i)) + 1.0);
+// 16
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.x) * intBitsToFloat(R126i.y));
+// 17
+R123i.x = ((R125i.w == 0)?(PV0i.w):(R12i.w));
+PV1i.x = R123i.x;
+// 18
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV1i.x)));
+PV0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.z), intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PV1i.x)));
+// 19
+PV1i.x = floatBitsToInt(intBitsToFloat(R126i.w) + intBitsToFloat(PV0i.z));
+PV1i.y = floatBitsToInt(intBitsToFloat(R124i.w) + intBitsToFloat(PV0i.w));
+PV1i.z = floatBitsToInt(intBitsToFloat(R127i.x) + intBitsToFloat(PV0i.y));
+// 20
+R123i.x = floatBitsToInt((intBitsToFloat(PV1i.y) * intBitsToFloat(0x3e22f983) + 0.5));
+PV0i.x = R123i.x;
+R123i.z = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0x3e22f983) + 0.5));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((intBitsToFloat(PV1i.x) * intBitsToFloat(0x3e22f983) + 0.5));
+PV0i.w = R123i.w;
+// 21
+PV1i.x = floatBitsToInt(fract(intBitsToFloat(PV0i.w)));
+PV1i.y = floatBitsToInt(fract(intBitsToFloat(PV0i.z)));
+PV1i.z = floatBitsToInt(fract(intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt(uf_blockVS7[13].x);
+PV1i.w = floatBitsToInt(intBitsToFloat(PV1i.w) / 2.0);
+// 22
+R123i.x = floatBitsToInt((intBitsToFloat(PV1i.x) * intBitsToFloat(0x40c90fdb) + intBitsToFloat(0xc0490fdb)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0x40c90fdb) + intBitsToFloat(0xc0490fdb)));
+PV0i.y = R123i.y;
+R5i.z = floatBitsToInt(intBitsToFloat(R9i.x) + intBitsToFloat(PV1i.w));
+R123i.w = floatBitsToInt((intBitsToFloat(PV1i.y) * intBitsToFloat(0x40c90fdb) + intBitsToFloat(0xc0490fdb)));
+PV0i.w = R123i.w;
+PS0i = floatBitsToInt(uf_blockVS7[13].y);
+PS0i = floatBitsToInt(intBitsToFloat(PS0i) / 2.0);
+// 23
+R127i.x = floatBitsToInt(intBitsToFloat(PV0i.x) * intBitsToFloat(0x3e22f983));
+PV1i.x = R127i.x;
+R3i.y = floatBitsToInt(intBitsToFloat(R9i.y) + intBitsToFloat(PS0i));
+R126i.z = floatBitsToInt(intBitsToFloat(PV0i.w) * intBitsToFloat(0x3e22f983));
+R126i.w = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(0x3e22f983));
+// 24
+R127i.w = floatBitsToInt(sin((intBitsToFloat(PV1i.x))/0.1591549367));
+PS0i = R127i.w;
+// 25
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(cos((intBitsToFloat(backupReg0i))/0.1591549367));
+PS1i = R127i.x;
+// 26
+R124i.z = floatBitsToInt(sin((intBitsToFloat(R126i.z))/0.1591549367));
+PS0i = R124i.z;
+// 27
+backupReg0i = R126i.z;
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS0i)));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PS0i)));
+R127i.y = floatBitsToInt(cos((intBitsToFloat(backupReg0i))/0.1591549367));
+PS1i = R127i.y;
+// 28
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS1i)));
+PV0i.x = R125i.x;
+R124i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PS1i)));
+PV0i.w = R124i.w;
+R3i.w = floatBitsToInt(sin((intBitsToFloat(R126i.w))/0.1591549367));
+PS0i = R3i.w;
+// 29
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PS0i), intBitsToFloat(PV0i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PS0i), intBitsToFloat(PV0i.x)));
+R11i.z = floatBitsToInt(-(intBitsToFloat(PS0i)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PS0i), intBitsToFloat(R126i.y)));
+R124i.x = floatBitsToInt(cos((intBitsToFloat(R126i.w))/0.1591549367));
+PS1i = R124i.x;
+// 30
+R5i.x = floatBitsToInt(intBitsToFloat(R126i.z) + intBitsToFloat(PV1i.y));
+R5i.y = floatBitsToInt(-(intBitsToFloat(R126i.y)) + intBitsToFloat(PV1i.x));
+R0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PS1i)));
+R5i.w = floatBitsToInt(-(intBitsToFloat(R124i.w)) + intBitsToFloat(PV1i.w));
+R2i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS1i)));
+PS0i = R2i.w;
+// 31
+R2i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(R124i.x)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), intBitsToFloat(R126i.z)));
+R1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), intBitsToFloat(R124i.x)));
+// 32
+R2i.z = floatBitsToInt(intBitsToFloat(R125i.x) + intBitsToFloat(PV1i.y));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R125i.x = floatBitsToInt(intBitsToFloat(R13i.x) + -(uf_blockVS6[17].x));
+PV0i.x = R125i.x;
+R127i.y = floatBitsToInt(intBitsToFloat(R12i.z) + -(uf_blockVS6[17].y));
+PV0i.y = R127i.y;
+R126i.z = floatBitsToInt(intBitsToFloat(R1i.y) + -(uf_blockVS6[17].z));
+PV0i.z = R126i.z;
+R127i.w = floatBitsToInt(-(intBitsToFloat(R13i.x)) + uf_blockVS6[17].x);
+R125i.y = floatBitsToInt(-(intBitsToFloat(R12i.z)) + uf_blockVS6[17].y);
+PS0i = R125i.y;
+// 1
+tempi.x = floatBitsToInt(dot(vec4(-(intBitsToFloat(PV0i.x)),-(intBitsToFloat(PV0i.y)),-(intBitsToFloat(PV0i.z)),-0.0),vec4(-(intBitsToFloat(PV0i.x)),-(intBitsToFloat(PV0i.y)),-(intBitsToFloat(PV0i.z)),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R124i.z = floatBitsToInt(-(intBitsToFloat(R1i.y)) + uf_blockVS6[17].z);
+PS1i = R124i.z;
+// 2
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R125i.x),intBitsToFloat(R127i.y),intBitsToFloat(R126i.z),-0.0),vec4(intBitsToFloat(R125i.x),intBitsToFloat(R127i.y),intBitsToFloat(R126i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+PS0i = floatBitsToInt(tempResultf);
+// 3
+PV1i.y = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R126i.z)), intBitsToFloat(PS0i)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R127i.y)), intBitsToFloat(PS0i)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(-(intBitsToFloat(R125i.x)), intBitsToFloat(PS0i)));
+PS1i = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+// 4
+R14i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.x), intBitsToFloat(PV1i.w)));
+PV0i.x = R14i.x;
+R14i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.x), intBitsToFloat(PV1i.y)));
+PV0i.z = R14i.z;
+R6i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.x), intBitsToFloat(PV1i.z)));
+PV0i.w = R6i.w;
+R126i.y = floatBitsToInt(1.0 / intBitsToFloat(PS1i));
+PS0i = R126i.y;
+// 5
+PV1i.x = floatBitsToInt(intBitsToFloat(R125i.x) + intBitsToFloat(PV0i.x));
+PV1i.y = floatBitsToInt(intBitsToFloat(R127i.y) + intBitsToFloat(PV0i.w));
+PV1i.z = floatBitsToInt(intBitsToFloat(R126i.z) + intBitsToFloat(PV0i.z));
+// 6
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),-0.0),vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+// 7
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R127i.w),intBitsToFloat(R125i.y),intBitsToFloat(R124i.z),-0.0),vec4(intBitsToFloat(R127i.w),intBitsToFloat(R125i.y),intBitsToFloat(R124i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+PS1i = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+// 8
+PV0i.w = floatBitsToInt(intBitsToFloat(PS1i) * intBitsToFloat(R126i.y));
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+R126i.y = floatBitsToInt(tempResultf);
+PS0i = R126i.y;
+// 9
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R0i.w), intBitsToFloat(PV0i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), intBitsToFloat(PV0i.w)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.z), intBitsToFloat(PV0i.w)));
+R124i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PS0i)));
+R127i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.y), intBitsToFloat(PS0i)));
+PS1i = R127i.w;
+// 10
+R127i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.z), intBitsToFloat(R3i.y)));
+R3i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.z), intBitsToFloat(PV1i.y)));
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), intBitsToFloat(R126i.y)));
+PV0i.z = R126i.z;
+R1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.x), intBitsToFloat(R5i.z)));
+PS0i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PS1i), -(uf_blockVS6[1].z)));
+// 11
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.z), -(uf_blockVS6[1].x)));
+R126i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS6[1].y,intBitsToFloat(PV0i.z)) + intBitsToFloat(PS0i)));
+R9i.z = R124i.w;
+PV1i.z = R9i.z;
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.w), -(uf_blockVS6[1].y)));
+R6i.z = R127i.w;
+PS1i = R6i.z;
+// 12
+R1i.x = R126i.z;
+PV0i.x = R1i.x;
+R125i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS6[1].z,intBitsToFloat(R124i.w)) + intBitsToFloat(PV1i.x)));
+PV0i.y = R125i.y;
+R124i.z = floatBitsToInt((mul_nonIEEE(uf_blockVS6[1].x,intBitsToFloat(R127i.w)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R124i.z;
+R126i.w = PV1i.z;
+R125i.z = PS1i;
+PS0i = R125i.z;
+// 13
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R126i.y),intBitsToFloat(PV0i.y),intBitsToFloat(PV0i.z),-0.0),vec4(intBitsToFloat(R126i.y),intBitsToFloat(PV0i.y),intBitsToFloat(PV0i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R127i.y = PV0i.x;
+PS1i = R127i.y;
+// 14
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.y), intBitsToFloat(R126i.w)));
+R124i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R126i.w)));
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.y), intBitsToFloat(PS1i)));
+R125i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.y), intBitsToFloat(R125i.z)));
+tempResultf = 1.0 / sqrt(intBitsToFloat(PV1i.x));
+PS0i = floatBitsToInt(tempResultf);
+// 15
+R9i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PS0i)));
+PV1i.x = R9i.x;
+R126i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R125i.z)));
+R5i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.z), intBitsToFloat(PS0i)));
+PV1i.z = R5i.z;
+R0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R125i.y), intBitsToFloat(PS0i)));
+PV1i.w = R0i.w;
+R125i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.x), intBitsToFloat(R127i.y)));
+PS1i = R125i.y;
+// 16
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.z), intBitsToFloat(PV1i.x)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.w), intBitsToFloat(PV1i.z)));
+R3i.z = PV1i.w;
+PV0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.w), intBitsToFloat(PV1i.w)));
+R3i.x = PV1i.z;
+PS0i = R3i.x;
+// 17
+R123i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R0i.w)),intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R5i.z)),intBitsToFloat(R124i.w)) + intBitsToFloat(PV0i.x)));
+PV1i.y = R123i.y;
+R124i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.z), intBitsToFloat(R127i.y)));
+R123i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R9i.x)),intBitsToFloat(R127i.w)) + intBitsToFloat(PV0i.w)));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.z), intBitsToFloat(R3i.y)));
+// 18
+R6i.x = PV1i.y;
+PV0i.x = R6i.x;
+R9i.y = PV1i.x;
+PV0i.y = R9i.y;
+R7i.z = PV1i.w;
+PV0i.z = R7i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(R2i.x)) + intBitsToFloat(PS1i)));
+PV0i.w = R123i.w;
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.z), intBitsToFloat(R126i.w)));
+PS0i = R126i.z;
+// 19
+backupReg0i = R2i.z;
+R124i.x = PV0i.y;
+PV1i.x = R124i.x;
+R127i.y = PV0i.x;
+PV1i.y = R127i.y;
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.w),intBitsToFloat(R5i.y)) + intBitsToFloat(PV0i.w)));
+R126i.w = PV0i.z;
+PV1i.w = R126i.w;
+R5i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(R125i.z)));
+PS1i = R5i.y;
+// 20
+backupReg0i = R127i.z;
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.y)) + intBitsToFloat(R125i.w)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.x)) + intBitsToFloat(R125i.x)));
+PV0i.y = R123i.y;
+R127i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.w),intBitsToFloat(PV1i.x)) + intBitsToFloat(R124i.y)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.x),intBitsToFloat(PV1i.w)) + intBitsToFloat(backupReg0i)));
+PV0i.w = R123i.w;
+R125i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.w),intBitsToFloat(PV1i.y)) + intBitsToFloat(R126i.y)));
+PS0i = R125i.w;
+// 21
+R7i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.z),intBitsToFloat(R5i.z)) + intBitsToFloat(PV0i.w)));
+R2i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.z),intBitsToFloat(R0i.w)) + intBitsToFloat(PV0i.x)));
+R13i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.z),intBitsToFloat(R9i.x)) + intBitsToFloat(PV0i.y)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.w),intBitsToFloat(R126i.w)) + intBitsToFloat(R125i.y)));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), intBitsToFloat(R3i.y)));
+// 22
+backupReg0i = R3i.w;
+R0i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(R9i.x)) + intBitsToFloat(R127i.z)));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(R11i.z)) + intBitsToFloat(PS1i)));
+PV0i.y = R123i.y;
+R11i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R3i.w)),intBitsToFloat(R0i.w)) + intBitsToFloat(R125i.w)));
+R3i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(backupReg0i)),intBitsToFloat(R5i.z)) + intBitsToFloat(PV1i.w)));
+R7i.w = 0x3f800000;
+PS0i = R7i.w;
+// 23
+R11i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.w),intBitsToFloat(R0i.z)) + intBitsToFloat(PV0i.y)));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(R126i.w)) + intBitsToFloat(R124i.z)));
+PV1i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(R127i.y)) + intBitsToFloat(R5i.y)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(R124i.x)) + intBitsToFloat(R126i.z)));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R5i.w), intBitsToFloat(R3i.y)));
+// 24
+backupReg0i = R1i.z;
+backupReg0i = R1i.z;
+backupReg1i = R0i.w;
+R2i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(R2i.w)) + intBitsToFloat(PS1i)));
+R3i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.z),intBitsToFloat(R9i.x)) + intBitsToFloat(PV1i.w)));
+R1i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(R5i.z)) + intBitsToFloat(PV1i.y)));
+R0i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(backupReg1i)) + intBitsToFloat(PV1i.z)));
+R5i.y = floatBitsToInt(intBitsToFloat(R12i.z) + intBitsToFloat(R6i.w));
+PS0i = R5i.y;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.z), intBitsToFloat(R3i.y)));
+R127i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.w),intBitsToFloat(R5i.x)) + intBitsToFloat(R2i.x)));
+PV0i.y = R127i.y;
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.z), intBitsToFloat(R0i.w)));
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.z), intBitsToFloat(R1i.z)));
+R1i.z = floatBitsToInt(intBitsToFloat(R1i.y) + intBitsToFloat(R14i.z));
+PS0i = R1i.z;
+// 1
+backupReg0i = R0i.x;
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R9i.x),intBitsToFloat(R9i.y),intBitsToFloat(R9i.z),-0.0),vec4(intBitsToFloat(R11i.x),intBitsToFloat(PV0i.y),intBitsToFloat(R2i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R127i.z = tempi.x;
+R124i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.y),intBitsToFloat(backupReg0i)) + intBitsToFloat(PV0i.x)));
+PS1i = R124i.z;
+// 2
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.z),intBitsToFloat(R6i.x),intBitsToFloat(R6i.z),-0.0),vec4(intBitsToFloat(R11i.x),intBitsToFloat(R127i.y),intBitsToFloat(R2i.z),0.0)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R127i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.y),intBitsToFloat(R3i.w)) + intBitsToFloat(R126i.w)));
+PS0i = R127i.x;
+// 3
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R3i.x),intBitsToFloat(R7i.z),intBitsToFloat(R1i.x),-0.0),vec4(intBitsToFloat(R11i.x),intBitsToFloat(R127i.y),intBitsToFloat(R2i.z),0.0)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+PS1i = floatBitsToInt(intBitsToFloat(R12i.z) + intBitsToFloat(PV0i.x));
+// 4
+R16i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),intBitsToFloat(R7i.x)) + intBitsToFloat(R127i.x)));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.y),intBitsToFloat(R11i.z)) + intBitsToFloat(R126i.z)));
+PV0i.y = R123i.y;
+R7i.z = floatBitsToInt(intBitsToFloat(R6i.w) + intBitsToFloat(PS1i));
+PV0i.w = floatBitsToInt(intBitsToFloat(R1i.y) + intBitsToFloat(PV1i.x));
+R3i.w = 0x3f800000;
+PS0i = R3i.w;
+// 5
+R15i.x = floatBitsToInt(intBitsToFloat(R14i.z) + intBitsToFloat(PV0i.w));
+R8i.y = floatBitsToInt(intBitsToFloat(R13i.x) + intBitsToFloat(R14i.x));
+R9i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),intBitsToFloat(R2i.y)) + intBitsToFloat(PV0i.y)));
+R11i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),intBitsToFloat(R13i.z)) + intBitsToFloat(R124i.z)));
+R8i.z = floatBitsToInt(uf_blockVS7[60].x);
+PS1i = R8i.z;
+// 6
+PV0i.x = floatBitsToInt(intBitsToFloat(R13i.x) + intBitsToFloat(R127i.z));
+R2i.y = floatBitsToInt(uf_blockVS7[60].y);
+R6i.w = floatBitsToInt(uf_blockVS7[60].z);
+// 7
+R5i.x = floatBitsToInt(intBitsToFloat(R14i.x) + intBitsToFloat(PV0i.x));
+PV1i.y = floatBitsToInt((uf_blockVS7[8].y > 0.0)?1.0:0.0);
+PV1i.z = floatBitsToInt((0.0 > uf_blockVS7[8].y)?1.0:0.0);
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[8].y);
+// 8
+PV0i.x = floatBitsToInt(intBitsToFloat(R12i.w) * intBitsToFloat(PS1i));
+R127i.y = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(PV1i.z)));
+PV0i.y = R127i.y;
+R125i.w = floatBitsToInt(-(uf_blockVS7[68].x) + uf_blockVS7[69].x);
+// 9
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.x),uf_blockVS7[9].z) + intBitsToFloat(PV0i.x)));
+PV1i.z = R123i.z;
+R126i.w = floatBitsToInt(-(intBitsToFloat(PV0i.y)) + 1.0);
+// 10
+PV0i.x = floatBitsToInt(-(uf_blockVS7[68].w) + uf_blockVS7[69].w);
+PV0i.y = floatBitsToInt(fract(intBitsToFloat(PV1i.z)));
+// 11
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV0i.y)));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PV0i.x));
+// 12
+R127i.y = floatBitsToInt(intBitsToFloat(R125i.w) * intBitsToFloat(PS1i));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R7i.y),intBitsToFloat(R126i.w)) + intBitsToFloat(PV1i.x)));
+PV0i.z = R123i.z;
+// 13
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.z) + -(uf_blockVS7[68].w));
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.z) + -(uf_blockVS7[69].w));
+// 14
+backupReg0i = R127i.y;
+R127i.x = ((intBitsToFloat(PV1i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.x = R127i.x;
+R127i.y = ((intBitsToFloat(PV1i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.y = R127i.y;
+R126i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.y),intBitsToFloat(backupReg0i)) + uf_blockVS7[68].x));
+// 15
+PV1i.z = floatBitsToInt(-(intBitsToFloat(PV0i.x)) + 1.0);
+PV1i.w = floatBitsToInt(-(intBitsToFloat(PV0i.y)) + 1.0);
+// 16
+PV0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PV1i.w)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[68].x, intBitsToFloat(PV1i.z)));
+// 17
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.w),intBitsToFloat(PV0i.x)) + intBitsToFloat(PV0i.y)));
+PV1i.w = R123i.w;
+// 18
+R14i.x = floatBitsToInt((mul_nonIEEE(uf_blockVS7[69].x,intBitsToFloat(R127i.y)) + intBitsToFloat(PV1i.w)));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R5i.x),intBitsToFloat(R7i.z),intBitsToFloat(R15i.x),intBitsToFloat(R7i.w)),vec4(uf_blockVS6[8].x,uf_blockVS6[8].y,uf_blockVS6[8].z,uf_blockVS6[8].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R9i.y = tempi.x;
+// 1
+R0i.x = floatBitsToInt(dot(vec4(intBitsToFloat(R5i.x),intBitsToFloat(R7i.z),intBitsToFloat(R15i.x),intBitsToFloat(R7i.w)),vec4(uf_blockVS6[9].x,uf_blockVS6[9].y,uf_blockVS6[9].z,uf_blockVS6[9].w)));
+PV1i.x = R0i.x;
+PV1i.y = R0i.x;
+PV1i.z = R0i.x;
+PV1i.w = R0i.x;
+// 2
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R5i.x),intBitsToFloat(R7i.z),intBitsToFloat(R15i.x),intBitsToFloat(R7i.w)),vec4(uf_blockVS6[10].x,uf_blockVS6[10].y,uf_blockVS6[10].z,uf_blockVS6[10].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R8i.w = tempi.x;
+// 3
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R5i.x),intBitsToFloat(R7i.z),intBitsToFloat(R15i.x),intBitsToFloat(R7i.w)),vec4(uf_blockVS6[11].x,uf_blockVS6[11].y,uf_blockVS6[11].z,uf_blockVS6[11].w)));
+PV1i.x = tempi.x;
+PV1i.y = tempi.x;
+PV1i.z = tempi.x;
+PV1i.w = tempi.x;
+R15i.z = tempi.x;
+// 4
+backupReg0i = R6i.w;
+R13i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.z), uf_blockVS8[0].x));
+PV0i.y = PV1i.x;
+PV0i.y = floatBitsToInt(intBitsToFloat(PV0i.y) / 2.0);
+R16i.z = floatBitsToInt((intBitsToFloat(R8i.w) * 0.0 + intBitsToFloat(PV1i.x)));
+PV0i.z = R16i.z;
+R6i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), uf_blockVS8[0].y));
+R7i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), uf_blockVS8[0].z));
+PS0i = R7i.w;
+// 5
+R123i.x = floatBitsToInt((intBitsToFloat(R8i.w) * 0.0 + intBitsToFloat(PV0i.y)));
+PV1i.x = R123i.x;
+R0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R14i.x), uf_blockVS8[0].w));
+R15i.w = floatBitsToInt((intBitsToFloat(R8i.w) * 0.5 + intBitsToFloat(PV0i.y)));
+PV1i.w = R15i.w;
+R9i.w = floatBitsToInt(1.0 / intBitsToFloat(PV0i.z));
+PS1i = R9i.w;
+// 6
+R17i.x = floatBitsToInt((intBitsToFloat(R9i.y) * 0.5 + intBitsToFloat(PV1i.x)));
+R11i.y = floatBitsToInt((intBitsToFloat(R0i.x) * -(0.5) + intBitsToFloat(PV1i.x)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.w) * intBitsToFloat(PS1i));
+// 7
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.z),uf_blockVS6[18].w) + -(uf_blockVS6[18].y)));
+PV1i.y = R123i.y;
+// 8
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R8i.y),intBitsToFloat(R5i.y),intBitsToFloat(R1i.z),intBitsToFloat(R3i.w)),vec4(uf_blockVS6[10].x,uf_blockVS6[10].y,uf_blockVS6[10].z,uf_blockVS6[10].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R127i.y = tempi.x;
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.y));
+// 9
+R12i.z = floatBitsToInt(-(uf_blockVS6[18].z) * intBitsToFloat(PS0i));
+// 10
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R8i.y),intBitsToFloat(R5i.y),intBitsToFloat(R1i.z),intBitsToFloat(R3i.w)),vec4(uf_blockVS6[11].x,uf_blockVS6[11].y,uf_blockVS6[11].z,uf_blockVS6[11].w)));
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+// 11
+PV1i.x = PV0i.x;
+PV1i.x = floatBitsToInt(intBitsToFloat(PV1i.x) / 2.0);
+R123i.y = floatBitsToInt((intBitsToFloat(R127i.y) * 0.0 + intBitsToFloat(PV0i.x)));
+PV1i.y = R123i.y;
+// 12
+R123i.z = floatBitsToInt((intBitsToFloat(R127i.y) * 0.5 + intBitsToFloat(PV1i.x)));
+PV0i.z = R123i.z;
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.y));
+// 13
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.z) * intBitsToFloat(PS0i));
+// 14
+PV0i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS6[18].w, intBitsToFloat(PV1i.x)));
+// 15
+PV1i.y = floatBitsToInt(-(uf_blockVS6[18].y) + intBitsToFloat(PV0i.z));
+// 16
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.y));
+// 17
+R3i.x = floatBitsToInt(-(uf_blockVS6[18].z) * intBitsToFloat(PS0i));
+// 18
+PV0i.x = ((intBitsToFloat(R10i.w) > 0.5)?int(0xFFFFFFFF):int(0x0));
+PV0i.y = ((intBitsToFloat(R10i.y) > 0.5)?int(0xFFFFFFFF):int(0x0));
+PV0i.z = ((intBitsToFloat(R10i.x) > 0.5)?int(0xFFFFFFFF):int(0x0));
+PV0i.w = ((intBitsToFloat(R10i.z) > 0.5)?int(0xFFFFFFFF):int(0x0));
+// 19
+R14i.x = ((PV0i.w == 0)?(R12i.x):(R16i.w));
+R8i.y = ((PV0i.z == 0)?(R12i.x):(R16i.w));
+R1i.z = ((PV0i.x == 0)?(R12i.y):(R17i.z));
+R3i.w = ((PV0i.y == 0)?(R12i.y):(R17i.z));
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+backupReg0i = R13i.x;
+R13i.x = floatBitsToInt(uf_blockVS7[76].x);
+R3i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.w), uf_blockVS7[59].x));
+R0i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), uf_blockVS7[59].x));
+R14i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.w), uf_blockVS7[59].x));
+R8i.z = floatBitsToInt(uf_blockVS7[76].y);
+PS0i = R8i.z;
+// 1
+PV1i.x = floatBitsToInt((0.0 > uf_blockVS7[8].w)?1.0:0.0);
+R2i.y = floatBitsToInt(uf_blockVS7[76].z);
+PV1i.z = ((intBitsToFloat(R10i.y) > 0.5)?int(0xFFFFFFFF):int(0x0));
+PV1i.w = floatBitsToInt((uf_blockVS7[8].w > 0.0)?1.0:0.0);
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[8].w);
+// 2
+PV0i.x = floatBitsToInt(uf_blockVS7[5].x) & 0x00080000;
+R125i.y = ((PV1i.z == 0)?(R12i.x):(R16i.w));
+R127i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + -(intBitsToFloat(PV1i.x)));
+PV0i.z = R127i.z;
+PV0i.w = floatBitsToInt(intBitsToFloat(R12i.w) * intBitsToFloat(PS1i));
+PS0i = floatBitsToInt(uf_blockVS7[5].x) & 0x00100000;
+// 3
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.x),uf_blockVS7[10].x) + intBitsToFloat(PV0i.w)));
+PV1i.x = R123i.x;
+R127i.y = floatBitsToInt(-(intBitsToFloat(PV0i.z)) + 1.0);
+PV1i.z = (PV0i.x == 0x00080000)?int(0xFFFFFFFF):int(0x0);
+PV1i.w = (PS0i == 0x00100000)?int(0xFFFFFFFF):int(0x0);
+PS1i = floatBitsToInt(uf_blockVS7[5].x) & 0x00200000;
+// 4
+R1i.x = ((PV1i.w == 0)?(R12i.y):(R3i.w));
+PV0i.y = (PS1i == 0x00200000)?int(0xFFFFFFFF):int(0x0);
+PV0i.z = floatBitsToInt(fract(intBitsToFloat(PV1i.x)));
+R0i.w = ((PV1i.z == 0)?(R12i.x):(R8i.y));
+PS0i = floatBitsToInt(uf_blockVS7[5].x) & 0x00400000;
+// 5
+PV1i.x = (PS0i == 0x00400000)?int(0xFFFFFFFF):int(0x0);
+PV1i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x00800000;
+R14i.z = ((PV0i.y == 0)?(R12i.x):(R14i.x));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.z), intBitsToFloat(PV0i.z)));
+PS1i = floatBitsToInt(uf_blockVS7[5].x) & 0x01000000;
+// 6
+R14i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R7i.y),intBitsToFloat(R127i.y)) + intBitsToFloat(PV1i.w)));
+R1i.y = ((PV1i.x == 0)?(R12i.y):(R1i.z));
+PV0i.z = (PV1i.y == 0x00800000)?int(0xFFFFFFFF):int(0x0);
+R126i.w = (PS1i == 0x01000000)?int(0xFFFFFFFF):int(0x0);
+PS0i = ((intBitsToFloat(R10i.z) > 0.5)?int(0xFFFFFFFF):int(0x0));
+// 7
+backupReg0i = R125i.y;
+R123i.x = ((PS0i == 0)?(R12i.y):(R17i.z));
+PV1i.x = R123i.x;
+R125i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x00000010;
+PV1i.z = floatBitsToInt(uf_blockVS7[5].y) & int(1);
+R1i.w = ((PV0i.z == 0)?(R12i.x):(backupReg0i));
+R6i.w = int(uf_blockVS7[17].x);
+PS1i = R6i.w;
+// 8
+R11i.x = ((R126i.w == 0)?(R12i.y):(PV1i.x));
+R8i.y = (int(1) != PV1i.z)?int(0xFFFFFFFF):int(0x0);
+R12i.x = int(uf_blockVS7[17].y);
+PS0i = R12i.x;
+// 9
+R12i.y = floatBitsToInt(float(R125i.y));
+PS1i = R12i.y;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(intBitsToFloat(R14i.x) + -(uf_blockVS7[85].w));
+R127i.z = floatBitsToInt(intBitsToFloat(R14i.x) + -(uf_blockVS7[84].w));
+PV0i.z = R127i.z;
+PV0i.w = floatBitsToInt(-(uf_blockVS7[84].w) + uf_blockVS7[85].w);
+// 1
+R127i.x = floatBitsToInt((intBitsToFloat(R12i.y) > 0.0)?1.0:0.0);
+PV1i.y = floatBitsToInt(-(uf_blockVS7[84].x) + uf_blockVS7[85].x);
+R124i.z = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.z = R124i.z;
+R126i.w = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R126i.w;
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PV0i.w));
+// 2
+backupReg0i = R8i.z;
+PV0i.x = floatBitsToInt(-(intBitsToFloat(PV1i.w)) + 1.0);
+PV0i.y = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 1.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.y) * intBitsToFloat(PS1i));
+R3i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R13i.x), uf_blockVS8[1].x));
+R8i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), uf_blockVS8[1].y));
+PS0i = R8i.z;
+// 3
+R13i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R2i.y), uf_blockVS8[1].z));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV0i.z)) + uf_blockVS7[84].x));
+PV1i.y = R123i.y;
+PV1i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[84].x, intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.w), intBitsToFloat(PV0i.y)));
+PS1i = floatBitsToInt((0.0 > intBitsToFloat(R12i.y))?1.0:0.0);
+// 4
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.w)) + intBitsToFloat(PV1i.z)));
+PV0i.y = R123i.y;
+PV0i.z = floatBitsToInt(intBitsToFloat(R127i.x) + -(intBitsToFloat(PS1i)));
+// 5
+R123i.w = floatBitsToInt((mul_nonIEEE(uf_blockVS7[85].x,intBitsToFloat(R124i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.w = R123i.w;
+R125i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R125i.y;
+// 6
+PV0i.x = 0 - PS1i;
+R16i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV1i.w), uf_blockVS8[1].w));
+// 7
+R14i.x = max(R125i.y, PV0i.x);
+R9i.x = floatBitsToInt(uf_blockVS8[3].x);
+PS1i = R9i.x;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R18i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[59].x, intBitsToFloat(R3i.w)));
+R13i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[59].x, intBitsToFloat(R13i.x)));
+R17i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[59].x, intBitsToFloat(R8i.z)));
+PV0i.w = floatBitsToInt(uf_blockVS7[5].x) & 0x00000020;
+R124i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00000040;
+PS0i = R124i.z;
+// 1
+R124i.x = int(-1) + R6i.w;
+R126i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x02000000;
+R127i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00000080;
+PS1i = floatBitsToInt(float(PV0i.w));
+// 2
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.w = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PS0i = floatBitsToInt(float(R124i.z));
+// 3
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PS1i = floatBitsToInt(float(R127i.z));
+// 4
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + -(intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+R125i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R125i.y;
+// 5
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.x)));
+PV1i.w = 0 - PS0i;
+R127i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R127i.y;
+// 6
+R8i.x = max(R125i.y, PV1i.w);
+PV0i.w = 0 - PS1i;
+R125i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R125i.y;
+// 7
+R13i.x = max(R127i.y, PV0i.w);
+PV1i.w = 0 - PS0i;
+R127i.z = floatBitsToInt(float(R6i.w));
+PS1i = R127i.z;
+// 8
+R126i.x = max(R125i.y, PV1i.w);
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.w), intBitsToFloat(PS1i)));
+R124i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R10i.x), intBitsToFloat(PS1i)));
+PS0i = floatBitsToInt(float(R12i.x));
+// 9
+PV1i.w = floatBitsToInt(intBitsToFloat(R6i.y) * intBitsToFloat(PV0i.y));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 10
+R126i.w = floatBitsToInt(intBitsToFloat(R12i.w) * intBitsToFloat(PS1i));
+PS0i = int(intBitsToFloat(PV1i.w));
+// 11
+R126i.z = R14i.x * PS0i;
+PS1i = R126i.z;
+// 12
+R14i.x = int(intBitsToFloat(R126i.w));
+PS0i = R14i.x;
+// 13
+PS1i = floatBitsToInt(float(PS0i));
+// 14
+PV0i.y = floatBitsToInt(-(intBitsToFloat(R127i.z)) + intBitsToFloat(PS1i));
+R127i.y = floatBitsToInt(float(R6i.w));
+PS0i = R127i.y;
+// 15
+R7i.x = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+R123i.w = ((intBitsToFloat(PV0i.y) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.w = R123i.w;
+R127i.w = floatBitsToInt(float(R14i.x));
+PS1i = R127i.w;
+// 16
+R125i.x = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+R127i.x = int(intBitsToFloat(PV1i.w));
+PS0i = R127i.x;
+// 17
+R125i.y = int(1) - PS0i;
+R12i.x = floatBitsToInt(1.0 / abs(intBitsToFloat(R127i.y)));
+PS1i = R12i.x;
+// 18
+backupReg0i = R127i.x;
+PV0i.z = floatBitsToInt(mul_nonIEEE(abs(intBitsToFloat(R127i.w)), intBitsToFloat(PS1i)));
+R127i.x = backupReg0i * R124i.x;
+PS0i = R127i.x;
+// 19
+PV1i.y = floatBitsToInt(trunc(intBitsToFloat(PV0i.z)));
+PS1i = floatBitsToInt(float(R126i.y));
+// 20
+backupReg0i = R124i.z;
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.y = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R124i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV1i.y)),intBitsToFloat(R7i.x)) + intBitsToFloat(R125i.x)));
+PV0i.z = R124i.z;
+R125i.w = int(intBitsToFloat(backupReg0i));
+PS0i = R125i.w;
+// 21
+PV1i.x = floatBitsToInt(-(abs(intBitsToFloat(R127i.y))) + intBitsToFloat(PV0i.z));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.y)));
+PV1i.w = floatBitsToInt((intBitsToFloat(PV0i.z) >= abs(intBitsToFloat(R127i.y)))?1.0:0.0);
+R126i.y = R126i.x * PS0i;
+PS1i = R126i.y;
+// 22
+R126i.x = ((intBitsToFloat(PV1i.w) == 0.0)?(R124i.z):(PV1i.x));
+PV0i.x = R126i.x;
+R126i.w = int(intBitsToFloat(PV1i.y));
+PS0i = R126i.w;
+// 23
+PV1i.x = 0 - PS0i;
+PV1i.z = floatBitsToInt(abs(intBitsToFloat(R127i.y)) + intBitsToFloat(PV0i.x));
+// 24
+R123i.y = ((-(intBitsToFloat(R126i.x)) > 0.0)?(PV1i.z):(R126i.x));
+PV0i.y = R123i.y;
+PV0i.z = max(R126i.w, PV1i.x);
+// 25
+R123i.w = ((-(intBitsToFloat(R127i.w)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.y)))):(PV0i.y));
+PV1i.w = R123i.w;
+PS1i = PV0i.z * R125i.w;
+// 26
+R126i.x = ((intBitsToFloat(R127i.y) == 0.0)?(R127i.w):(PV1i.w));
+PV0i.z = R14i.x + PS1i;
+// 27
+R127i.w = R13i.x * PV0i.z;
+PS1i = R127i.w;
+// 28
+PS0i = int(intBitsToFloat(R126i.x));
+// 29
+PS1i = R125i.y * PS0i;
+// 30
+PV0i.z = PS1i + R127i.x;
+// 31
+PS1i = R8i.x * PV0i.z;
+// 32
+PV0i.y = PS1i + R126i.z;
+// 33
+PV1i.w = R127i.w + PV0i.y;
+// 34
+PV0i.x = R126i.y + PV1i.w;
+// 35
+R124i.z = floatBitsToInt(float(PV0i.x));
+PS1i = R124i.z;
+// 36
+R127i.x = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+PV0i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.x), abs(intBitsToFloat(PS1i))));
+// 37
+PV1i.w = floatBitsToInt(trunc(intBitsToFloat(PV0i.y)));
+// 38
+R126i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV1i.w)),intBitsToFloat(R7i.x)) + intBitsToFloat(R127i.x)));
+PV0i.z = R126i.z;
+// 39
+PV1i.y = floatBitsToInt(-(abs(intBitsToFloat(R127i.y))) + intBitsToFloat(PV0i.z));
+PV1i.w = floatBitsToInt((intBitsToFloat(PV0i.z) >= abs(intBitsToFloat(R127i.y)))?1.0:0.0);
+// 40
+R127i.x = ((intBitsToFloat(PV1i.w) == 0.0)?(R126i.z):(PV1i.y));
+PV0i.x = R127i.x;
+// 41
+PV1i.z = floatBitsToInt(abs(intBitsToFloat(R127i.y)) + intBitsToFloat(PV0i.x));
+// 42
+R123i.y = ((-(intBitsToFloat(R127i.x)) > 0.0)?(PV1i.z):(R127i.x));
+PV0i.y = R123i.y;
+// 43
+R123i.w = ((-(intBitsToFloat(R124i.z)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.y)))):(PV0i.y));
+PV1i.w = R123i.w;
+// 44
+R123i.x = ((intBitsToFloat(R127i.y) == 0.0)?(R124i.z):(PV1i.w));
+PV0i.x = R123i.x;
+// 45
+R124i.z = int(intBitsToFloat(PV0i.x));
+PS1i = R124i.z;
+// 46
+R2i.y = floatBitsToInt(float(PS1i));
+PS0i = R2i.y;
+// 47
+R7i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+R6i.w = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R3i.w = floatBitsToInt(float(R124i.z));
+PS1i = R3i.w;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(abs(intBitsToFloat(R3i.w)) * 0.25);
+R127i.y = floatBitsToInt(abs(intBitsToFloat(R3i.w)));
+PV0i.z = floatBitsToInt(intBitsToFloat(R6i.w) + -(intBitsToFloat(R7i.x)));
+// 1
+R123i.y = floatBitsToInt((intBitsToFloat(PV0i.z) * 0.5 + intBitsToFloat(R2i.y)));
+PV1i.y = R123i.y;
+PV1i.z = floatBitsToInt(trunc(intBitsToFloat(PV0i.x)));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.y) * 0.25);
+R13i.z = ((R8i.y == 0)?(R10i.x):(R10i.y));
+R127i.w = floatBitsToInt((-(intBitsToFloat(PV1i.z)) * 4.0 + intBitsToFloat(R127i.y)));
+PV0i.w = R127i.w;
+// 3
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.w) + intBitsToFloat(0xc0800000));
+PV1i.y = floatBitsToInt(trunc(intBitsToFloat(PV0i.x)));
+PV1i.z = floatBitsToInt((intBitsToFloat(PV0i.w) >= 4.0)?1.0:0.0);
+R12i.y = int(uf_blockVS7[26].x);
+PS1i = R12i.y;
+// 4
+R127i.x = floatBitsToInt(uf_blockVS7[5].x) & 0x00000100;
+R127i.y = ((intBitsToFloat(PV1i.z) == 0.0)?(R127i.w):(PV1i.x));
+PV0i.y = R127i.y;
+PS0i = int(intBitsToFloat(PV1i.y));
+// 5
+R2i.y = PS0i + 0x00000012;
+PV1i.w = floatBitsToInt(intBitsToFloat(PV0i.y) + 4.0);
+R6i.w = int(uf_blockVS7[26].y);
+PS1i = R6i.w;
+// 6
+R123i.x = ((-(intBitsToFloat(R127i.y)) > 0.0)?(PV1i.w):(R127i.y));
+PV0i.x = R123i.x;
+PS0i = floatBitsToInt(float(R127i.x));
+// 7
+PV1i.y = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R123i.z = ((-(intBitsToFloat(R3i.w)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.x)))):(PV0i.x));
+PV1i.z = R123i.z;
+PV1i.w = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+// 8
+R126i.x = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(PV1i.w)));
+PS0i = int(intBitsToFloat(PV1i.z));
+// 9
+R127i.x = 0xfffffffe + PS0i;
+R127i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x00000200;
+R124i.z = 0xfffffffd + PS0i;
+PV1i.w = int(-1) + PS0i;
+PS1i = floatBitsToInt(float(PS0i));
+// 10
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.z = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PS0i = floatBitsToInt(float(PV1i.w));
+// 11
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.z)));
+PV1i.z = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PS1i = floatBitsToInt(float(R127i.x));
+// 12
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.y = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.z) + -(intBitsToFloat(PV1i.x)));
+R127i.w = int(intBitsToFloat(PV1i.y));
+PS0i = R127i.w;
+// 13
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.x)));
+PV1i.y = 0 - PS0i;
+R127i.x = int(intBitsToFloat(PV0i.w));
+PS1i = R127i.x;
+// 14
+PV0i.x = 0 - PS1i;
+PV0i.z = max(R127i.w, PV1i.y);
+R126i.z = int(intBitsToFloat(PV1i.x));
+PS0i = R126i.z;
+// 15
+R8i.x = int(1) - PV0i.z;
+PV1i.y = max(R127i.x, PV0i.x);
+PV1i.z = 0 - PS0i;
+PS1i = floatBitsToInt(float(R124i.z));
+// 16
+R12i.x = int(1) - PV1i.y;
+PV0i.y = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.z = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.w = max(R126i.z, PV1i.z);
+R126i.z = int(intBitsToFloat(R126i.x));
+PS0i = R126i.z;
+// 17
+R7i.x = int(1) - PV0i.w;
+PV1i.y = 0 - PS0i;
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.z)));
+PS1i = floatBitsToInt(float(R127i.y));
+// 18
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.y = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+R3i.w = max(R126i.z, PV1i.y);
+R127i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R127i.y;
+// 19
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.x)));
+PV1i.w = 0 - PS0i;
+// 20
+PV0i.x = max(R127i.y, PV1i.w);
+R1i.z = int(intBitsToFloat(PV1i.x));
+PS0i = R1i.z;
+// 21
+R8i.z = int(1) - PV0i.x;
+}
+if( activeMaskStackC[3] == true ) {
+R2i.xyzw = floatBitsToInt(uf_blockVS7[R2i.y].xyzw);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R127i.x = floatBitsToInt(uf_blockVS7[5].x) & 0x00000400;
+PV0i.y = 0 - R1i.z;
+R126i.z = floatBitsToInt(uf_blockVS7[5].x) & 0x00000800;
+R125i.w = int(-1) + R12i.y;
+R127i.y = R8i.z * R2i.w;
+PS0i = R127i.y;
+// 1
+R7i.w = max(R1i.z, PV0i.y);
+R127i.w = R7i.x * R2i.z;
+PS1i = R127i.w;
+// 2
+R126i.x = R12i.x * R2i.y;
+PS0i = R126i.x;
+// 3
+PS1i = R8i.x * R2i.x;
+// 4
+PV0i.y = R126i.x + PS1i;
+PS0i = floatBitsToInt(float(R127i.x));
+// 5
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.y = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PV1i.w = R127i.w + PV0i.y;
+PS1i = floatBitsToInt(float(R126i.z));
+// 6
+R8i.x = R127i.y + PV1i.w;
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.y) + -(intBitsToFloat(PV1i.x)));
+PV0i.z = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R127i.x = floatBitsToInt(float(R12i.y));
+PS0i = R127i.x;
+// 7
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.z) + -(intBitsToFloat(PV0i.w)));
+R127i.y = floatBitsToInt(uf_blockVS7[5].x) & 0x04000000;
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R12i.w), intBitsToFloat(PS0i)));
+R126i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R13i.z), intBitsToFloat(PS0i)));
+R126i.z = int(intBitsToFloat(PV0i.y));
+PS1i = R126i.z;
+// 8
+PV0i.x = 0 - PS1i;
+PV0i.y = floatBitsToInt(intBitsToFloat(R6i.y) * intBitsToFloat(PV1i.z));
+R124i.z = int(intBitsToFloat(PV1i.x));
+PS0i = R124i.z;
+// 9
+PV1i.y = 0 - PS0i;
+R2i.w = max(R126i.z, PV0i.x);
+PS1i = int(intBitsToFloat(PV0i.y));
+// 10
+R124i.w = max(R124i.z, PV1i.y);
+R125i.x = R3i.w * PS1i;
+PS0i = R125i.x;
+// 11
+PS1i = floatBitsToInt(float(R6i.w));
+// 12
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PS1i));
+// 13
+PV1i.y = floatBitsToInt(intBitsToFloat(R12i.w) * intBitsToFloat(PS0i));
+R126i.z = floatBitsToInt(float(R12i.y));
+PS1i = R126i.z;
+// 14
+R124i.y = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+R6i.w = int(intBitsToFloat(PV1i.y));
+PS0i = R6i.w;
+// 15
+PS1i = floatBitsToInt(float(PS0i));
+// 16
+PV0i.z = floatBitsToInt(-(intBitsToFloat(R127i.x)) + intBitsToFloat(PS1i));
+R126i.y = floatBitsToInt(float(R6i.w));
+PS0i = R126i.y;
+// 17
+R123i.y = ((intBitsToFloat(PV0i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.y = R123i.y;
+R127i.w = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+R3i.w = floatBitsToInt(1.0 / abs(intBitsToFloat(R126i.z)));
+PS1i = R3i.w;
+// 18
+PV0i.x = floatBitsToInt(mul_nonIEEE(abs(intBitsToFloat(R126i.y)), intBitsToFloat(PS1i)));
+PS0i = int(intBitsToFloat(PV1i.y));
+// 19
+backupReg0i = R125i.w;
+R126i.x = int(1) - PS0i;
+PV1i.z = floatBitsToInt(trunc(intBitsToFloat(PV0i.x)));
+R125i.w = PS0i * backupReg0i;
+PS1i = R125i.w;
+// 20
+R127i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV1i.z)),intBitsToFloat(R124i.y)) + intBitsToFloat(R127i.w)));
+PV0i.x = R127i.x;
+PS0i = floatBitsToInt(float(R127i.y));
+// 21
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.y = floatBitsToInt((intBitsToFloat(PV0i.x) >= abs(intBitsToFloat(R126i.z)))?1.0:0.0);
+PV1i.z = floatBitsToInt(-(abs(intBitsToFloat(R126i.z))) + intBitsToFloat(PV0i.x));
+PV1i.w = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R125i.y = int(intBitsToFloat(R126i.w));
+PS1i = R125i.y;
+// 22
+backupReg0i = R124i.w;
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + -(intBitsToFloat(PV1i.x)));
+R124i.w = ((intBitsToFloat(PV1i.y) == 0.0)?(R127i.x):(PV1i.z));
+PV0i.w = R124i.w;
+R124i.z = backupReg0i * PS1i;
+PS0i = R124i.z;
+// 23
+PV1i.x = floatBitsToInt(abs(intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.w));
+R127i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R127i.y;
+// 24
+R123i.z = ((-(intBitsToFloat(R124i.w)) > 0.0)?(PV1i.x):(R124i.w));
+PV0i.z = R123i.z;
+PV0i.w = 0 - PS1i;
+// 25
+PV1i.x = max(R127i.y, PV0i.w);
+R123i.y = ((-(intBitsToFloat(R126i.y)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.z)))):(PV0i.z));
+PV1i.y = R123i.y;
+// 26
+R123i.w = ((intBitsToFloat(R126i.z) == 0.0)?(R126i.y):(PV1i.y));
+PV0i.w = R123i.w;
+PS0i = PV1i.x * R125i.y;
+// 27
+R127i.x = R6i.w + PS0i;
+PS1i = int(intBitsToFloat(PV0i.w));
+// 28
+PS0i = R126i.x * PS1i;
+// 29
+PV1i.x = PS0i + R125i.w;
+R126i.y = R2i.w * R127i.x;
+PS1i = R126i.y;
+// 30
+PS0i = R7i.w * PV1i.x;
+// 31
+PV1i.z = PS0i + R125i.x;
+// 32
+PV0i.y = R126i.y + PV1i.z;
+// 33
+PV1i.w = R124i.z + PV0i.y;
+// 34
+R127i.x = floatBitsToInt(float(PV1i.w));
+PS0i = R127i.x;
+// 35
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R3i.w), abs(intBitsToFloat(PS0i))));
+R125i.w = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+// 36
+PV0i.y = floatBitsToInt(trunc(intBitsToFloat(PV1i.z)));
+// 37
+R125i.x = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.y)),intBitsToFloat(R124i.y)) + intBitsToFloat(R125i.w)));
+PV1i.x = R125i.x;
+// 38
+PV0i.y = floatBitsToInt((intBitsToFloat(PV1i.x) >= abs(intBitsToFloat(R126i.z)))?1.0:0.0);
+PV0i.z = floatBitsToInt(-(abs(intBitsToFloat(R126i.z))) + intBitsToFloat(PV1i.x));
+// 39
+R125i.w = ((intBitsToFloat(PV0i.y) == 0.0)?(R125i.x):(PV0i.z));
+PV1i.w = R125i.w;
+// 40
+PV0i.x = floatBitsToInt(abs(intBitsToFloat(R126i.z)) + intBitsToFloat(PV1i.w));
+// 41
+R123i.z = ((-(intBitsToFloat(R125i.w)) > 0.0)?(PV0i.x):(R125i.w));
+PV1i.z = R123i.z;
+// 42
+R123i.y = ((-(intBitsToFloat(R127i.x)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV1i.z)))):(PV1i.z));
+PV0i.y = R123i.y;
+// 43
+R123i.w = ((intBitsToFloat(R126i.z) == 0.0)?(R127i.x):(PV0i.y));
+PV1i.w = R123i.w;
+// 44
+R127i.x = int(intBitsToFloat(PV1i.w));
+PS0i = R127i.x;
+// 45
+R13i.z = floatBitsToInt(float(PS0i));
+PS1i = R13i.z;
+// 46
+PV0i.y = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R12i.y = floatBitsToInt(float(R127i.x));
+PS0i = R12i.y;
+// 47
+R2i.x = floatBitsToInt(intBitsToFloat(PV0i.y) + -(intBitsToFloat(PV0i.w)));
+R2i.z = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+R3i.w = floatBitsToInt(abs(intBitsToFloat(PS0i)) * 0.25);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(trunc(intBitsToFloat(R3i.w)));
+R123i.z = floatBitsToInt((intBitsToFloat(R2i.x) * 0.5 + intBitsToFloat(R13i.z)));
+PV0i.z = R123i.z;
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.z) * 0.25);
+R124i.y = floatBitsToInt((-(intBitsToFloat(PV0i.x)) * 4.0 + intBitsToFloat(R2i.z)));
+PV1i.y = R124i.y;
+// 2
+PV0i.x = floatBitsToInt((intBitsToFloat(PV1i.y) >= 4.0)?1.0:0.0);
+PV0i.y = floatBitsToInt(trunc(intBitsToFloat(PV1i.x)));
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + intBitsToFloat(0xc0800000));
+// 3
+R126i.z = ((intBitsToFloat(PV0i.x) == 0.0)?(R124i.y):(PV0i.w));
+PV1i.z = R126i.z;
+PS1i = int(intBitsToFloat(PV0i.y));
+// 4
+PV0i.y = floatBitsToInt(intBitsToFloat(PV1i.z) + 4.0);
+R2i.z = PS1i + 0x0000001b;
+PS0i = int(uf_blockVS7[48].z);
+// 5
+R123i.w = ((-(intBitsToFloat(R126i.z)) > 0.0)?(PV0i.y):(R126i.z));
+PV1i.w = R123i.w;
+R1i.z = floatBitsToInt(float(PS0i));
+PS1i = R1i.z;
+// 6
+R123i.x = ((-(intBitsToFloat(R12i.y)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV1i.w)))):(PV1i.w));
+PV0i.x = R123i.x;
+R12i.y = floatBitsToInt(float(R8i.x));
+PS0i = R12i.y;
+// 7
+PS1i = int(intBitsToFloat(PV0i.x));
+// 8
+R127i.x = 0xfffffffd + PS1i;
+PV0i.y = int(-1) + PS1i;
+R126i.z = floatBitsToInt(abs(intBitsToFloat(R1i.z)));
+R125i.w = 0xfffffffe + PS1i;
+PS0i = floatBitsToInt(float(PS1i));
+// 9
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.w = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PS1i = floatBitsToInt(float(PV0i.y));
+// 10
+PV0i.x = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+PV0i.y = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.w) + -(intBitsToFloat(PV1i.x)));
+PS0i = floatBitsToInt(float(R125i.w));
+// 11
+PV1i.x = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+PV1i.y = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.y)));
+PV1i.z = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+R124i.y = int(intBitsToFloat(PV0i.z));
+PS1i = R124i.y;
+// 12
+PV0i.x = 0 - PS1i;
+PV0i.w = floatBitsToInt(intBitsToFloat(PV1i.z) + -(intBitsToFloat(PV1i.x)));
+R125i.w = int(intBitsToFloat(PV1i.y));
+PS0i = R125i.w;
+// 13
+PV1i.x = max(R124i.y, PV0i.x);
+PV1i.y = 0 - PS0i;
+R125i.x = int(intBitsToFloat(PV0i.w));
+PS1i = R125i.x;
+// 14
+R7i.x = int(1) - PV1i.x;
+PV0i.y = 0 - PS1i;
+PV0i.z = max(R125i.w, PV1i.y);
+PS0i = floatBitsToInt(float(R127i.x));
+// 15
+R12i.x = int(1) - PV0i.z;
+PV1i.y = max(R125i.x, PV0i.y);
+PV1i.z = floatBitsToInt((intBitsToFloat(PS0i) > 0.0)?1.0:0.0);
+PV1i.w = floatBitsToInt((0.0 > intBitsToFloat(PS0i))?1.0:0.0);
+R7i.w = floatBitsToInt(float(R8i.x));
+PS1i = R7i.w;
+// 16
+PV0i.x = floatBitsToInt(intBitsToFloat(PV1i.z) + -(intBitsToFloat(PV1i.w)));
+R124i.y = floatBitsToInt(abs(intBitsToFloat(PS1i)));
+R3i.w = int(1) - PV1i.y;
+PS0i = floatBitsToInt(1.0 / abs(intBitsToFloat(R1i.z)));
+// 17
+PV1i.z = floatBitsToInt(mul_nonIEEE(abs(intBitsToFloat(R7i.w)), intBitsToFloat(PS0i)));
+R124i.z = int(intBitsToFloat(PV0i.x));
+PS1i = R124i.z;
+// 18
+PV0i.x = floatBitsToInt(trunc(intBitsToFloat(PV1i.z)));
+PV0i.y = 0 - PS1i;
+// 19
+backupReg0i = R126i.z;
+R126i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV0i.x)),intBitsToFloat(backupReg0i)) + intBitsToFloat(R124i.y)));
+PV1i.z = R126i.z;
+PV1i.w = max(R124i.z, PV0i.y);
+// 20
+R8i.x = int(1) - PV1i.w;
+PV0i.y = floatBitsToInt(-(abs(intBitsToFloat(R1i.z))) + intBitsToFloat(PV1i.z));
+PV0i.w = floatBitsToInt((intBitsToFloat(PV1i.z) >= abs(intBitsToFloat(R1i.z)))?1.0:0.0);
+// 21
+R2i.x = ((intBitsToFloat(PV0i.w) == 0.0)?(R126i.z):(PV0i.y));
+PV1i.x = R2i.x;
+// 22
+R13i.z = floatBitsToInt(abs(intBitsToFloat(R1i.z)) + intBitsToFloat(PV1i.x));
+}
+if( activeMaskStackC[3] == true ) {
+R6i.xyzw = floatBitsToInt(uf_blockVS7[R2i.z].xyzw);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt((intBitsToFloat(R12i.y) > 0.0)?1.0:0.0);
+R123i.y = ((-(intBitsToFloat(R2i.x)) > 0.0)?(R13i.z):(R2i.x));
+PV0i.y = R123i.y;
+R126i.z = floatBitsToInt(uf_blockVS7[44].z + uf_blockVS7[45].x);
+PV0i.w = floatBitsToInt((0.0 > intBitsToFloat(R12i.y))?1.0:0.0);
+R127i.z = R8i.x * R6i.w;
+PS0i = R127i.z;
+// 1
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.x) + -(intBitsToFloat(PV0i.w)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R10i.x), uf_blockVS7[45].x));
+PV1i.y = floatBitsToInt(intBitsToFloat(PV1i.y) * 2.0);
+R124i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R10i.y), uf_blockVS7[45].y));
+R124i.z = floatBitsToInt(intBitsToFloat(R124i.z) * 2.0);
+R123i.w = ((-(intBitsToFloat(R7i.w)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.y)))):(PV0i.y));
+PV1i.w = R123i.w;
+R126i.y = R3i.w * R6i.z;
+PS1i = R126i.y;
+// 2
+R125i.x = ((intBitsToFloat(R1i.z) == 0.0)?(R7i.w):(PV1i.w));
+R124i.y = floatBitsToInt(-(intBitsToFloat(PV1i.y)) + intBitsToFloat(R126i.z));
+R126i.z = floatBitsToInt((intBitsToFloat(PV1i.x) * 0.5 + intBitsToFloat(R12i.y)));
+PV0i.w = floatBitsToInt(uf_blockVS7[44].w + uf_blockVS7[45].y);
+R125i.w = R12i.x * R6i.y;
+PS0i = R125i.w;
+// 3
+PV1i.x = floatBitsToInt(uf_blockVS7[46].x + uf_blockVS7[46].z);
+PV1i.y = floatBitsToInt(uf_blockVS7[46].y + uf_blockVS7[46].w);
+R124i.w = floatBitsToInt(-(intBitsToFloat(R124i.z)) + intBitsToFloat(PV0i.w));
+PS1i = R7i.x * R6i.x;
+// 4
+backupReg0i = R124i.y;
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.x),uf_blockVS7[46].z) + intBitsToFloat(PV1i.x)));
+PV0i.x = R123i.x;
+R124i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R12i.w)),uf_blockVS7[44].x) + -(intBitsToFloat(backupReg0i))));
+PV0i.z = R125i.w + PS1i;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.y),uf_blockVS7[46].w) + intBitsToFloat(PV1i.y)));
+PV0i.w = R123i.w;
+R124i.z = int(intBitsToFloat(R125i.x));
+PS0i = R124i.z;
+// 5
+R125i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[44].y) + intBitsToFloat(R124i.w)));
+PV1i.y = R126i.y + PV0i.z;
+R125i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[45].z) + intBitsToFloat(PV0i.x)));
+R125i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[45].w) + intBitsToFloat(PV0i.w)));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(R1i.z));
+// 6
+PV0i.x = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(PS1i));
+R126i.w = R127i.z + PV1i.y;
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[48].z);
+// 7
+PV1i.x = floatBitsToInt(trunc(intBitsToFloat(PV0i.x)));
+R123i.y = ((R8i.y == 0)?(0):(int(1)));
+PV1i.y = R123i.y;
+R124i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[48].x, intBitsToFloat(PS0i)));
+PV1i.w = R124i.w;
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[48].w);
+// 8
+R127i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.w),intBitsToFloat(PV1i.w)) + -(0.5)));
+R126i.y = (PV1i.y == int(1))?int(0xFFFFFFFF):int(0x0);
+PV0i.y = R126i.y;
+R126i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[48].y, intBitsToFloat(PS1i)));
+PV0i.z = R126i.z;
+PV0i.w = (PV1i.y == 0x00000002)?int(0xFFFFFFFF):int(0x0);
+R127i.z = int(intBitsToFloat(PV1i.x));
+PS0i = R127i.z;
+// 9
+backupReg0i = R124i.z;
+R123i.x = ((PV0i.w == 0)?(R10i.y):(R10i.x));
+PV1i.x = R123i.x;
+R125i.y = ((PV0i.y == 0)?(R10i.x):(R10i.y));
+R124i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.x),intBitsToFloat(PV0i.z)) + -(0.5)));
+R123i.w = ((PV0i.w == 0)?(R10i.x):(R10i.z));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(float(backupReg0i));
+// 10
+R123i.x = ((R126i.y == 0)?(PV1i.x):(R10i.z));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.w),intBitsToFloat(PS1i)) + intBitsToFloat(R124i.y)));
+PV0i.y = R123i.y;
+R123i.z = ((R126i.y == 0)?(PV1i.w):(R10i.y));
+PV0i.z = R123i.z;
+R127i.w = ((R126i.y == 0)?(R10i.y):(R10i.z));
+PS0i = floatBitsToInt(float(R127i.z));
+// 11
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[50].y, intBitsToFloat(PV0i.x)));
+R127i.x = floatBitsToInt(intBitsToFloat(R127i.x) * 2.0);
+R6i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.z),intBitsToFloat(backupReg0i)) + intBitsToFloat(PV0i.y)));
+R123i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R126i.z)),intBitsToFloat(PS0i)) + intBitsToFloat(R125i.x)));
+PV1i.z = R123i.z;
+R124i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[50].x, intBitsToFloat(PV0i.z)));
+R124i.w = floatBitsToInt(intBitsToFloat(R124i.w) * 2.0);
+PS1i = int(uf_blockVS7[53].z);
+// 12
+PV0i.x = floatBitsToInt(uf_blockVS7[49].z + uf_blockVS7[50].x);
+PV0i.y = floatBitsToInt(uf_blockVS7[49].w + uf_blockVS7[50].y);
+R3i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.w),intBitsToFloat(R124i.z)) + -(intBitsToFloat(PV1i.z))));
+R127i.y = floatBitsToInt(float(PS1i));
+PS0i = R127i.y;
+// 13
+backupReg0i = R127i.x;
+R127i.x = floatBitsToInt(-(intBitsToFloat(backupReg0i)) + intBitsToFloat(PV0i.y));
+R126i.y = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+R124i.z = floatBitsToInt(-(intBitsToFloat(R124i.w)) + intBitsToFloat(PV0i.x));
+PV1i.w = floatBitsToInt(uf_blockVS7[51].x + uf_blockVS7[51].z);
+R124i.w = floatBitsToInt(float(R126i.w));
+PS1i = R124i.w;
+// 14
+backupReg0i = R125i.y;
+PV0i.x = floatBitsToInt((0.0 > intBitsToFloat(PS1i))?1.0:0.0);
+R125i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS7[51].z,intBitsToFloat(backupReg0i)) + intBitsToFloat(PV1i.w)));
+PV0i.z = floatBitsToInt(uf_blockVS7[51].y + uf_blockVS7[51].w);
+PV0i.w = floatBitsToInt((intBitsToFloat(PS1i) > 0.0)?1.0:0.0);
+R126i.x = floatBitsToInt(float(R126i.w));
+PS0i = R126i.x;
+// 15
+R125i.x = floatBitsToInt((mul_nonIEEE(uf_blockVS7[51].w,intBitsToFloat(R127i.w)) + intBitsToFloat(PV0i.z)));
+R124i.y = floatBitsToInt(abs(intBitsToFloat(PS0i)));
+PV1i.z = floatBitsToInt(intBitsToFloat(PV0i.w) + -(intBitsToFloat(PV0i.x)));
+R0i.w = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R12i.w)),uf_blockVS7[49].x) + -(intBitsToFloat(R124i.z))));
+PS1i = floatBitsToInt(1.0 / abs(intBitsToFloat(R127i.y)));
+// 16
+PV0i.x = floatBitsToInt(mul_nonIEEE(abs(intBitsToFloat(R126i.x)), intBitsToFloat(PS1i)));
+R123i.y = floatBitsToInt((intBitsToFloat(PV1i.z) * 0.5 + intBitsToFloat(R124i.w)));
+PV0i.y = R123i.y;
+R126i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[49].y) + intBitsToFloat(R127i.x)));
+R6i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[50].z) + intBitsToFloat(R125i.y)));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(R127i.y));
+// 17
+PV1i.x = floatBitsToInt(intBitsToFloat(PV0i.y) * intBitsToFloat(PS0i));
+R125i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[50].w) + intBitsToFloat(R125i.x)));
+R124i.z = ((R8i.y == 0)?(0):(0x00000002));
+PV1i.z = R124i.z;
+PV1i.w = floatBitsToInt(trunc(intBitsToFloat(PV0i.x)));
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[53].z);
+// 18
+backupReg0i = R126i.y;
+R1i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[53].x, intBitsToFloat(PS1i)));
+PV0i.x = R1i.x;
+R126i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PV1i.w)),intBitsToFloat(backupReg0i)) + intBitsToFloat(R124i.y)));
+PV0i.y = R126i.y;
+PV0i.z = floatBitsToInt(trunc(intBitsToFloat(PV1i.x)));
+R124i.w = (PV1i.z == int(1))?int(0xFFFFFFFF):int(0x0);
+PS0i = floatBitsToInt(1.0 / uf_blockVS7[53].w);
+// 19
+PV1i.x = floatBitsToInt((intBitsToFloat(PV0i.y) >= abs(intBitsToFloat(R127i.y)))?1.0:0.0);
+R124i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[53].y, intBitsToFloat(PS0i)));
+PV1i.y = R124i.y;
+R1i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R14i.z),intBitsToFloat(PV0i.x)) + -(0.5)));
+PV1i.w = floatBitsToInt(-(abs(intBitsToFloat(R127i.y))) + intBitsToFloat(PV0i.y));
+PS1i = int(intBitsToFloat(PV0i.z));
+// 20
+backupReg0i = R126i.y;
+backupReg1i = R124i.z;
+R7i.x = ((R124i.w == 0)?(R10i.x):(R10i.y));
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.y),intBitsToFloat(PV1i.y)) + -(0.5)));
+R124i.z = ((intBitsToFloat(PV1i.x) == 0.0)?(backupReg0i):(PV1i.w));
+PV0i.z = R124i.z;
+PV0i.w = (backupReg1i == 0x00000002)?int(0xFFFFFFFF):int(0x0);
+PS0i = floatBitsToInt(float(PS1i));
+// 21
+PV1i.x = floatBitsToInt(abs(intBitsToFloat(R127i.y)) + intBitsToFloat(PV0i.z));
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R124i.y)),intBitsToFloat(PS0i)) + intBitsToFloat(R126i.z)));
+PV1i.y = R123i.y;
+R123i.z = ((PV0i.w == 0)?(R10i.x):(R10i.z));
+PV1i.z = R123i.z;
+R123i.w = ((PV0i.w == 0)?(R10i.y):(R10i.x));
+PV1i.w = R123i.w;
+R6i.z = ((R124i.w == 0)?(R10i.y):(R10i.z));
+PS1i = R6i.z;
+// 22
+R6i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.y),intBitsToFloat(R126i.y)) + -(intBitsToFloat(PV1i.y))));
+R1i.y = ((R124i.w == 0)?(PV1i.z):(R10i.y));
+R14i.z = ((R124i.w == 0)?(PV1i.w):(R10i.z));
+R123i.w = ((-(intBitsToFloat(R124i.z)) > 0.0)?(PV1i.x):(R124i.z));
+PV0i.w = R123i.w;
+PS0i = int(uf_blockVS7[58].z);
+// 23
+R123i.x = ((-(intBitsToFloat(R126i.x)) > 0.0)?(floatBitsToInt(-(intBitsToFloat(PV0i.w)))):(PV0i.w));
+PV1i.x = R123i.x;
+R7i.w = floatBitsToInt(float(PS0i));
+PS1i = R7i.w;
+// 24
+R10i.x = floatBitsToInt(-(abs(intBitsToFloat(PS1i))) + 0.0);
+R10i.y = floatBitsToInt((0.0 >= abs(intBitsToFloat(PS1i)))?1.0:0.0);
+R10i.z = ((intBitsToFloat(R127i.y) == 0.0)?(R126i.x):(PV1i.x));
+R10i.w = floatBitsToInt(1.0 / intBitsToFloat(PS1i));
+PS0i = R10i.w;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+PV0i.x = floatBitsToInt(intBitsToFloat(R10i.w) * 0.0);
+R127i.y = ((intBitsToFloat(R10i.y) == 0.0)?(0):(R10i.x));
+PV0i.y = R127i.y;
+PS0i = int(intBitsToFloat(R10i.z));
+// 1
+PV1i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[55].x, intBitsToFloat(R1i.y)));
+PV1i.x = floatBitsToInt(intBitsToFloat(PV1i.x) * 2.0);
+PV1i.y = floatBitsToInt(uf_blockVS7[54].z + uf_blockVS7[55].x);
+PV1i.z = floatBitsToInt(trunc(intBitsToFloat(PV0i.x)));
+PV1i.w = floatBitsToInt(abs(intBitsToFloat(R7i.w)) + intBitsToFloat(PV0i.y));
+PS1i = floatBitsToInt(float(PS0i));
+// 2
+R123i.x = ((-(intBitsToFloat(R127i.y)) > 0.0)?(PV1i.w):(R127i.y));
+PV0i.x = R123i.x;
+R124i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[55].y, intBitsToFloat(R14i.z)));
+R124i.y = floatBitsToInt(intBitsToFloat(R124i.y) * 2.0);
+PV0i.z = floatBitsToInt(-(intBitsToFloat(PV1i.x)) + intBitsToFloat(PV1i.y));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.x),intBitsToFloat(PS1i)) + intBitsToFloat(R0i.w)));
+PV0i.w = R123i.w;
+R125i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R125i.y;
+// 3
+R13i.x = floatBitsToInt(intBitsToFloat(R6i.y) + 0.5);
+R126i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R12i.w)),uf_blockVS7[54].x) + -(intBitsToFloat(PV0i.z))));
+R123i.z = ((intBitsToFloat(R7i.w) == 0.0)?(0):(PV0i.x));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.w),intBitsToFloat(R1i.z)) + intBitsToFloat(PV0i.w)));
+PV1i.w = R123i.w;
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[58].z);
+// 4
+R126i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[58].x, intBitsToFloat(PS1i)));
+PV0i.x = R126i.x;
+R8i.y = floatBitsToInt(intBitsToFloat(R3i.w) + 0.5);
+R5i.z = floatBitsToInt(intBitsToFloat(R6i.x) + 0.5);
+R13i.w = floatBitsToInt(intBitsToFloat(PV1i.w) + 0.5);
+R127i.y = int(intBitsToFloat(PV1i.z));
+PS0i = R127i.y;
+// 5
+R125i.x = floatBitsToInt(intBitsToFloat(R3i.x) + -(uf_blockVS7[93].x));
+R10i.y = floatBitsToInt(intBitsToFloat(R7i.y) + 0.0);
+PV1i.y = R10i.y;
+R124i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.w),intBitsToFloat(PV0i.x)) + -(0.5)));
+R124i.w = floatBitsToInt(-(uf_blockVS7[93].x) + uf_blockVS7[93].y);
+PS1i = floatBitsToInt(1.0 / uf_blockVS7[58].w);
+// 6
+backupReg0i = R127i.y;
+R14i.x = R7i.y;
+R127i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS7[58].y, intBitsToFloat(PS1i)));
+PV0i.y = R127i.y;
+R125i.z = floatBitsToInt(intBitsToFloat(PV1i.y) + -(uf_blockVS7[104].w));
+PS0i = floatBitsToInt(float(backupReg0i));
+// 7
+backupReg0i = R126i.y;
+PV1i.x = floatBitsToInt(uf_blockVS7[54].w + uf_blockVS7[55].y);
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R11i.x),intBitsToFloat(PV0i.y)) + -(0.5)));
+R127i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.x),intBitsToFloat(PS0i)) + intBitsToFloat(backupReg0i)));
+R126i.x = floatBitsToInt(float(R125i.y));
+PS1i = R126i.x;
+// 8
+PV0i.x = floatBitsToInt(-(intBitsToFloat(R124i.y)) + intBitsToFloat(PV1i.x));
+PV0i.z = floatBitsToInt(uf_blockVS7[56].x + uf_blockVS7[56].z);
+PV0i.w = floatBitsToInt(uf_blockVS7[56].y + uf_blockVS7[56].w);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(R124i.w));
+// 9
+R123i.x = floatBitsToInt((mul_nonIEEE(uf_blockVS7[56].w,intBitsToFloat(R6i.z)) + intBitsToFloat(PV0i.w)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS7[56].z,intBitsToFloat(R7i.x)) + intBitsToFloat(PV0i.z)));
+PV1i.y = R123i.y;
+R3i.z = floatBitsToInt(intBitsToFloat(R125i.x) * intBitsToFloat(PS0i));
+R3i.z = clampFI32(R3i.z);
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[54].y) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+// 10
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[55].w) + intBitsToFloat(PV1i.x)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(R127i.y)),intBitsToFloat(R126i.x)) + intBitsToFloat(PV1i.w)));
+PV0i.y = R123i.y;
+R127i.z = floatBitsToInt(intBitsToFloat(R10i.y) + -(uf_blockVS7[105].w));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.w),uf_blockVS7[55].z) + intBitsToFloat(PV1i.y)));
+PV0i.w = R123i.w;
+// 11
+backupReg0i = R124i.z;
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),intBitsToFloat(R126i.y)) + -(intBitsToFloat(PV0i.y))));
+PV1i.x = R123i.x;
+R126i.y = floatBitsToInt(-(uf_blockVS7[104].x) + uf_blockVS7[105].x);
+R124i.z = floatBitsToInt(-(uf_blockVS7[104].y) + uf_blockVS7[105].y);
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.w),intBitsToFloat(backupReg0i)) + intBitsToFloat(R127i.w)));
+PV1i.w = R123i.w;
+// 12
+R24i.x = floatBitsToInt(intBitsToFloat(PV1i.w) + 0.5);
+R2i.y = floatBitsToInt(intBitsToFloat(PV1i.x) + 0.5);
+PV0i.z = floatBitsToInt(-(uf_blockVS7[104].w) + uf_blockVS7[105].w);
+R127i.w = floatBitsToInt(-(uf_blockVS7[104].z) + uf_blockVS7[105].z);
+// 13
+R126i.x = floatBitsToInt(-(uf_blockVS7[105].x) + uf_blockVS7[106].x);
+R126i.z = floatBitsToInt(-(uf_blockVS7[105].y) + uf_blockVS7[106].y);
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PV0i.z));
+// 14
+R125i.x = floatBitsToInt(-(uf_blockVS7[105].z) + uf_blockVS7[106].z);
+PV0i.y = floatBitsToInt(intBitsToFloat(R127i.w) * intBitsToFloat(PS1i));
+PV0i.z = floatBitsToInt(intBitsToFloat(R126i.y) * intBitsToFloat(PS1i));
+PV0i.w = floatBitsToInt(intBitsToFloat(R124i.z) * intBitsToFloat(PS1i));
+PS0i = floatBitsToInt(-(uf_blockVS7[105].w) + uf_blockVS7[106].w);
+// 15
+R10i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.z),intBitsToFloat(PV0i.z)) + uf_blockVS7[104].x));
+R10i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.z),intBitsToFloat(PV0i.w)) + uf_blockVS7[104].y));
+R6i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.z),intBitsToFloat(PV0i.y)) + uf_blockVS7[104].z));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 16
+backupReg0i = R125i.x;
+R125i.x = floatBitsToInt(intBitsToFloat(R10i.y) + -(uf_blockVS7[106].w));
+PV0i.y = floatBitsToInt(intBitsToFloat(backupReg0i) * intBitsToFloat(PS1i));
+PV0i.z = floatBitsToInt(intBitsToFloat(R126i.x) * intBitsToFloat(PS1i));
+PV0i.w = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(PS1i));
+R127i.w = floatBitsToInt(-(uf_blockVS7[106].z) + uf_blockVS7[107].z);
+PS0i = R127i.w;
+// 17
+R12i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV0i.z)) + uf_blockVS7[105].x));
+R13i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV0i.w)) + uf_blockVS7[105].y));
+R7i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.z),intBitsToFloat(PV0i.y)) + uf_blockVS7[105].z));
+// 18
+R126i.x = floatBitsToInt(-(uf_blockVS7[106].x) + uf_blockVS7[107].x);
+R126i.z = floatBitsToInt(-(uf_blockVS7[106].y) + uf_blockVS7[107].y);
+// 19
+R124i.x = floatBitsToInt(intBitsToFloat(R10i.y) + -(uf_blockVS7[107].w));
+PV1i.y = floatBitsToInt(-(uf_blockVS7[106].w) + uf_blockVS7[107].w);
+R14i.z = ((intBitsToFloat(R125i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+// 20
+R127i.x = floatBitsToInt(-(uf_blockVS7[107].x) + uf_blockVS7[108].x);
+R6i.y = ((intBitsToFloat(R127i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+R127i.z = floatBitsToInt(-(uf_blockVS7[107].y) + uf_blockVS7[108].y);
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PV1i.y));
+// 21
+backupReg0i = R126i.x;
+R126i.x = floatBitsToInt(-(uf_blockVS7[107].z) + uf_blockVS7[108].z);
+PV1i.y = floatBitsToInt(intBitsToFloat(R127i.w) * intBitsToFloat(PS0i));
+PV1i.z = floatBitsToInt(intBitsToFloat(backupReg0i) * intBitsToFloat(PS0i));
+PV1i.w = floatBitsToInt(intBitsToFloat(R126i.z) * intBitsToFloat(PS0i));
+PS1i = floatBitsToInt(-(uf_blockVS7[107].w) + uf_blockVS7[108].w);
+// 22
+R2i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.x),intBitsToFloat(PV1i.z)) + uf_blockVS7[106].x));
+R127i.y = ((intBitsToFloat(R125i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+R2i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.x),intBitsToFloat(PV1i.w)) + uf_blockVS7[106].y));
+R10i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.x),intBitsToFloat(PV1i.y)) + uf_blockVS7[106].z));
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(PS1i));
+// 23
+R3i.x = floatBitsToInt(intBitsToFloat(R10i.y) + -(uf_blockVS7[108].w));
+PV1i.x = R3i.x;
+PV1i.y = floatBitsToInt(intBitsToFloat(R126i.x) * intBitsToFloat(PS0i));
+PV1i.z = floatBitsToInt(intBitsToFloat(R127i.x) * intBitsToFloat(PS0i));
+PV1i.w = floatBitsToInt(intBitsToFloat(R127i.z) * intBitsToFloat(PS0i));
+R1i.w = floatBitsToInt(-(uf_blockVS7[108].z) + uf_blockVS7[109].z);
+PS1i = R1i.w;
+// 24
+R8i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.x),intBitsToFloat(PV1i.z)) + uf_blockVS7[107].x));
+R126i.y = ((intBitsToFloat(R124i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.y = R126i.y;
+R8i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.x),intBitsToFloat(PV1i.w)) + uf_blockVS7[107].y));
+R5i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.x),intBitsToFloat(PV1i.y)) + uf_blockVS7[107].z));
+R7i.y = ((intBitsToFloat(PV1i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PS0i = R7i.y;
+// 25
+R7i.x = floatBitsToInt(-(uf_blockVS7[108].x) + uf_blockVS7[109].x);
+PV1i.y = floatBitsToInt(-(intBitsToFloat(PV0i.y)) + 1.0);
+R6i.z = floatBitsToInt(-(uf_blockVS7[108].y) + uf_blockVS7[109].y);
+PV1i.w = floatBitsToInt(-(intBitsToFloat(PS0i)) + 1.0);
+R127i.w = floatBitsToInt(-(intBitsToFloat(R127i.y)) + 1.0);
+PS1i = R127i.w;
+// 26
+R1i.x = floatBitsToInt(intBitsToFloat(R10i.y) + -(uf_blockVS7[109].w));
+PV0i.x = R1i.x;
+PV0i.y = floatBitsToInt(-(uf_blockVS7[108].w) + uf_blockVS7[109].w);
+R11i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PV1i.w)));
+R2i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), intBitsToFloat(PV1i.y)));
+R3i.w = floatBitsToInt(-(intBitsToFloat(R14i.z)) + 1.0);
+PS0i = R3i.w;
+// 27
+R6i.x = floatBitsToInt(-(uf_blockVS7[109].x) + uf_blockVS7[110].x);
+R1i.y = ((intBitsToFloat(PV0i.x) >= 0.0)?(floatBitsToInt(1.0)):(0));
+R1i.z = floatBitsToInt(-(uf_blockVS7[109].y) + uf_blockVS7[110].y);
+R0i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R6i.y), intBitsToFloat(R127i.w)));
+R11i.x = floatBitsToInt(1.0 / intBitsToFloat(PV0i.y));
+PS1i = R11i.x;
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R124i.x = floatBitsToInt(-(uf_blockVS7[109].z) + uf_blockVS7[110].z);
+PV0i.y = floatBitsToInt(intBitsToFloat(R1i.w) * intBitsToFloat(R11i.x));
+PV0i.z = floatBitsToInt(intBitsToFloat(R7i.x) * intBitsToFloat(R11i.x));
+PV0i.w = floatBitsToInt(intBitsToFloat(R6i.z) * intBitsToFloat(R11i.x));
+PS0i = floatBitsToInt(-(uf_blockVS7[109].w) + uf_blockVS7[110].w);
+// 1
+R126i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.x),intBitsToFloat(PV0i.z)) + uf_blockVS7[108].x));
+PV1i.y = floatBitsToInt(-(intBitsToFloat(R1i.y)) + 1.0);
+R126i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.x),intBitsToFloat(PV0i.w)) + uf_blockVS7[108].y));
+R126i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R3i.x),intBitsToFloat(PV0i.y)) + uf_blockVS7[108].z));
+PS1i = floatBitsToInt(1.0 / intBitsToFloat(PS0i));
+// 2
+PV0i.x = floatBitsToInt(intBitsToFloat(R6i.x) * intBitsToFloat(PS1i));
+PV0i.y = floatBitsToInt(intBitsToFloat(R124i.x) * intBitsToFloat(PS1i));
+R125i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R7i.y), intBitsToFloat(PV1i.y)));
+PV0i.w = floatBitsToInt(intBitsToFloat(R1i.z) * intBitsToFloat(PS1i));
+R126i.y = floatBitsToInt(intBitsToFloat(R10i.y) + -(uf_blockVS7[110].w));
+PS0i = R126i.y;
+// 3
+R125i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.x),intBitsToFloat(PV0i.x)) + uf_blockVS7[109].x));
+R124i.y = ((intBitsToFloat(PS0i) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV1i.y = R124i.y;
+R124i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.x),intBitsToFloat(PV0i.w)) + uf_blockVS7[109].y));
+R125i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R1i.x),intBitsToFloat(PV0i.y)) + uf_blockVS7[109].z));
+PS1i = floatBitsToInt(-(intBitsToFloat(R6i.y)) + 1.0);
+// 4
+R124i.x = floatBitsToInt(-(uf_blockVS7[110].x) + uf_blockVS7[111].x);
+R127i.y = floatBitsToInt(-(uf_blockVS7[110].y) + uf_blockVS7[111].y);
+R127i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R14i.z), intBitsToFloat(PS1i)));
+PV0i.w = floatBitsToInt(-(intBitsToFloat(PV1i.y)) + 1.0);
+// 5
+PV1i.x = floatBitsToInt(-(uf_blockVS7[110].w) + uf_blockVS7[111].w);
+R125i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.y), intBitsToFloat(PV0i.w)));
+PV1i.z = floatBitsToInt(intBitsToFloat(R10i.y) + -(uf_blockVS7[111].w));
+R127i.w = floatBitsToInt(-(uf_blockVS7[110].z) + uf_blockVS7[111].z);
+// 6
+PV0i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS7[104].x, intBitsToFloat(R3i.w)));
+R1i.y = ((intBitsToFloat(PV1i.z) >= 0.0)?(floatBitsToInt(1.0)):(0));
+PV0i.z = floatBitsToInt(mul_nonIEEE(uf_blockVS7[104].y, intBitsToFloat(R3i.w)));
+PV0i.w = floatBitsToInt(mul_nonIEEE(uf_blockVS7[104].z, intBitsToFloat(R3i.w)));
+R127i.x = floatBitsToInt(1.0 / intBitsToFloat(PV1i.x));
+PS0i = R127i.x;
+// 7
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R6i.w),intBitsToFloat(R127i.z)) + intBitsToFloat(PV0i.w)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.z),intBitsToFloat(R127i.z)) + intBitsToFloat(PV0i.z)));
+PV1i.y = R123i.y;
+PV1i.z = floatBitsToInt(intBitsToFloat(R124i.x) * intBitsToFloat(PS0i));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.x),intBitsToFloat(R127i.z)) + intBitsToFloat(PV0i.x)));
+PV1i.w = R123i.w;
+R124i.w = floatBitsToInt(intBitsToFloat(R127i.y) * intBitsToFloat(PS0i));
+PS1i = R124i.w;
+// 8
+PV0i.x = floatBitsToInt(intBitsToFloat(R127i.w) * intBitsToFloat(R127i.x));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R7i.w),intBitsToFloat(R0i.w)) + intBitsToFloat(PV1i.x)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.x),intBitsToFloat(R0i.w)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R13i.z),intBitsToFloat(R0i.w)) + intBitsToFloat(PV1i.y)));
+PV0i.w = R123i.w;
+R127i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.y),intBitsToFloat(PV1i.z)) + uf_blockVS7[110].x));
+PS0i = R127i.x;
+// 9
+backupReg0i = R126i.y;
+backupReg0i = R126i.y;
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.x),intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.z)));
+PV1i.x = R123i.x;
+R126i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(R124i.w)) + uf_blockVS7[110].y));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R2i.z),intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.w)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R10i.w),intBitsToFloat(R2i.w)) + intBitsToFloat(PV0i.y)));
+PV1i.w = R123i.w;
+R124i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(backupReg0i),intBitsToFloat(PV0i.x)) + uf_blockVS7[110].z));
+PS1i = R124i.w;
+// 10
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.z),intBitsToFloat(R11i.z)) + intBitsToFloat(PV1i.z)));
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R8i.x),intBitsToFloat(R11i.z)) + intBitsToFloat(PV1i.x)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R5i.w),intBitsToFloat(R11i.z)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+PV0i.w = floatBitsToInt(-(intBitsToFloat(R1i.y)) + 1.0);
+R127i.y = floatBitsToInt(fract(intBitsToFloat(R4i.w)));
+PS0i = R127i.y;
+// 11
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.w),intBitsToFloat(R125i.z)) + intBitsToFloat(PV0i.z)));
+PV1i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.z),intBitsToFloat(R125i.z)) + intBitsToFloat(PV0i.x)));
+PV1i.y = R123i.y;
+R126i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R124i.y), intBitsToFloat(PV0i.w)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.x),intBitsToFloat(R125i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.w = R123i.w;
+R126i.x = floatBitsToInt(intBitsToFloat(R12i.w) * intBitsToFloat(0x42c80000));
+R126i.x = clampFI32(R126i.x);
+PS1i = R126i.x;
+// 12
+backupReg0i = R0i.x;
+R0i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R9i.y), intBitsToFloat(PS1i)));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.w),intBitsToFloat(R125i.y)) + intBitsToFloat(PV1i.x)));
+PV0i.y = R123i.y;
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R125i.x),intBitsToFloat(R125i.y)) + intBitsToFloat(PV1i.w)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.z),intBitsToFloat(R125i.y)) + intBitsToFloat(PV1i.y)));
+PV0i.w = R123i.w;
+R4i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(backupReg0i), intBitsToFloat(PS1i)));
+PS0i = R4i.z;
+// 13
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R127i.x),intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.z)));
+PV1i.x = R123i.x;
+R9i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R8i.w), intBitsToFloat(R126i.x)));
+R123i.z = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.y),intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.w)));
+PV1i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R124i.w),intBitsToFloat(R126i.z)) + intBitsToFloat(PV0i.y)));
+PV1i.w = R123i.w;
+R4i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.y), uf_blockVS11[5].z));
+PS1i = R4i.x;
+// 14
+R123i.x = floatBitsToInt((mul_nonIEEE(uf_blockVS7[111].x,intBitsToFloat(R1i.y)) + intBitsToFloat(PV1i.x)));
+PV0i.x = R123i.x;
+R123i.z = floatBitsToInt((mul_nonIEEE(uf_blockVS7[111].y,intBitsToFloat(R1i.y)) + intBitsToFloat(PV1i.z)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(uf_blockVS7[111].z,intBitsToFloat(R1i.y)) + intBitsToFloat(PV1i.w)));
+PV0i.w = R123i.w;
+// 15
+R6i.y = PV0i.x;
+R2i.z = PV0i.w;
+R7i.y = PV0i.z;
+PS1i = R7i.y;
+// 16
+R3i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R9i.x),intBitsToFloat(R3i.z)) + 0.0));
+PV0i.y = floatBitsToInt(intBitsToFloat(R11i.y) * intBitsToFloat(R9i.w));
+// 17
+PV1i.w = floatBitsToInt(-(intBitsToFloat(PV0i.y)) + 1.0);
+// 18
+R1i.y = floatBitsToInt((intBitsToFloat(PV1i.w) * intBitsToFloat(0x3f333333) + intBitsToFloat(0x3e19999a)));
+R1i.y = clampFI32(R1i.y);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R127i.x = floatBitsToInt(uf_blockVS6[17].x + -(intBitsToFloat(R5i.x)));
+R126i.y = floatBitsToInt(uf_blockVS6[17].y + -(intBitsToFloat(R7i.z)));
+PV0i.w = floatBitsToInt(min(uf_blockVS6[17].y, uf_blockVS13[27].z));
+// 1
+R126i.x = floatBitsToInt(uf_blockVS6[17].z + -(intBitsToFloat(R15i.x)));
+PV1i.x = R126i.x;
+PV1i.y = floatBitsToInt(-(intBitsToFloat(R1i.y)) + 1.0);
+PV1i.z = floatBitsToInt(-(intBitsToFloat(R5i.y)) + intBitsToFloat(PV0i.w));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),uf_blockVS13[24].x) + -(uf_blockVS13[24].y)));
+R123i.w = clampFI32(R123i.w);
+PV1i.w = R123i.w;
+// 2
+R123i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R12i.z),uf_blockVS13[22].x) + -(uf_blockVS13[22].y)));
+R123i.x = clampFI32(R123i.x);
+PV0i.x = R123i.x;
+R123i.y = floatBitsToInt((mul_nonIEEE(uf_blockVS13[27].y,intBitsToFloat(PV1i.z)) + uf_blockVS13[27].x));
+R123i.y = clampFI32(R123i.y);
+PV0i.y = R123i.y;
+PV0i.z = floatBitsToInt(-(intBitsToFloat(PV1i.w)) + 1.0);
+R124i.w = floatBitsToInt(intBitsToFloat(PV1i.y) + intBitsToFloat(0x41080000));
+PS0i = floatBitsToInt(intBitsToFloat(PV1i.x) * intBitsToFloat(PV1i.x));
+// 3
+R15i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(PV0i.y), uf_blockVS13[26].w));
+R123i.y = floatBitsToInt((intBitsToFloat(R126i.y) * intBitsToFloat(R126i.y) + intBitsToFloat(PS0i)));
+PV1i.y = R123i.y;
+PV1i.z = floatBitsToInt(uf_blockVS13[28].y + 1.0);
+PV1i.w = floatBitsToInt(-(intBitsToFloat(PV0i.x)) + 1.0);
+tempResultf = log2(intBitsToFloat(PV0i.z));
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS1i = floatBitsToInt(tempResultf);
+// 4
+PV0i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS13[24].w, intBitsToFloat(PS1i)));
+R127i.y = floatBitsToInt((intBitsToFloat(R127i.x) * intBitsToFloat(R127i.x) + intBitsToFloat(PV1i.y)));
+PV0i.z = floatBitsToInt(intBitsToFloat(PV1i.z) * 1.5);
+PV0i.z = clampFI32(PV0i.z);
+R125i.w = floatBitsToInt((uf_blockVS13[28].y * 1.0 + intBitsToFloat(R12i.z)));
+tempResultf = log2(intBitsToFloat(PV1i.w));
+if( isinf(tempResultf) == true ) tempResultf = -3.40282347E+38F;
+PS0i = floatBitsToInt(tempResultf);
+// 5
+R125i.x = floatBitsToInt(mul_nonIEEE(uf_blockVS13[23].x, intBitsToFloat(PS0i)));
+R125i.y = floatBitsToInt(mul_nonIEEE(uf_blockVS13[23].y, intBitsToFloat(PS0i)));
+R12i.z = floatBitsToInt(intBitsToFloat(R124i.w) * intBitsToFloat(0x3daaaaab));
+R124i.w = floatBitsToInt(intBitsToFloat(PV0i.z) * intBitsToFloat(0x41700000));
+PS1i = floatBitsToInt(exp2(intBitsToFloat(PV0i.x)));
+// 6
+R5i.x = ((0.0 >= intBitsToFloat(R3i.z))?int(0xFFFFFFFF):int(0x0));
+R12i.y = 0;
+R3i.z = floatBitsToInt((mul_nonIEEE(-(intBitsToFloat(PS1i)),uf_blockVS13[25].w) + uf_blockVS13[25].w));
+R4i.w = floatBitsToInt(uf_blockVS6[18].y * intBitsToFloat(0x40a00000));
+tempResultf = 1.0 / sqrt(intBitsToFloat(R127i.y));
+PS0i = floatBitsToInt(tempResultf);
+// 7
+PV1i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(PS0i)));
+PV1i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.y), intBitsToFloat(PS0i)));
+PV1i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R126i.x), intBitsToFloat(PS0i)));
+R5i.w = 0;
+PS1i = floatBitsToInt(exp2(intBitsToFloat(R125i.y)));
+PS1i = floatBitsToInt(intBitsToFloat(PS1i) / 2.0);
+// 8
+tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(PV1i.x),intBitsToFloat(PV1i.y),intBitsToFloat(PV1i.z),-0.0),vec4(uf_blockVS13[28].x,uf_blockVS13[28].y,uf_blockVS13[28].z,0.0)));
+tempi.x = floatBitsToInt(intBitsToFloat(tempi.x) / 2.0);
+PV0i.x = tempi.x;
+PV0i.y = tempi.x;
+PV0i.z = tempi.x;
+PV0i.w = tempi.x;
+R1i.y = floatBitsToInt(intBitsToFloat(PS1i) + 0.5);
+PS0i = R1i.y;
+// 9
+R2i.x = 0;
+R5i.y = ((R5i.x == 0)?(R0i.x):(R5i.w));
+R126i.z = floatBitsToInt(intBitsToFloat(PV0i.x) + 0.5);
+PV1i.z = R126i.z;
+R8i.w = 0;
+PV1i.w = R8i.w;
+PS1i = floatBitsToInt(exp2(intBitsToFloat(R125i.x)));
+// 10
+PV0i.x = floatBitsToInt(-(intBitsToFloat(PV1i.z)) + 1.0);
+R4i.y = ((R5i.x == 0)?(R4i.z):(PV1i.w));
+R123i.z = floatBitsToInt((intBitsToFloat(PV1i.z) * intBitsToFloat(0xbc996e30) + intBitsToFloat(0x3d981626)));
+PV0i.z = R123i.z;
+R123i.w = floatBitsToInt((mul_nonIEEE(-(uf_blockVS13[23].z),intBitsToFloat(PS1i)) + uf_blockVS13[23].z));
+R123i.w = clampFI32(R123i.w);
+PV0i.w = R123i.w;
+PS0i = floatBitsToInt(1.0 / intBitsToFloat(R124i.w));
+// 11
+PV1i.x = floatBitsToInt(intBitsToFloat(R125i.w) * intBitsToFloat(PS0i));
+R123i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.z),intBitsToFloat(PV0i.z)) + intBitsToFloat(0xbe593484)));
+PV1i.y = R123i.y;
+R7i.z = ((R5i.x == 0)?(R9i.y):(R4i.w));
+PV1i.w = floatBitsToInt(-(intBitsToFloat(R4i.x)) + intBitsToFloat(PV0i.w));
+PV1i.w = clampFI32(PV1i.w);
+PS1i = floatBitsToInt(sqrt(intBitsToFloat(PV0i.x)));
+// 12
+PV0i.x = floatBitsToInt(intBitsToFloat(PS1i) * intBitsToFloat(0x3f22f983));
+R9i.y = PV1i.w;
+PV0i.z = floatBitsToInt(max(intBitsToFloat(PV1i.x), intBitsToFloat(0x3e4ccccd)));
+R123i.w = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R126i.z),intBitsToFloat(PV1i.y)) + intBitsToFloat(0x3fc90da4)));
+PV0i.w = R123i.w;
+R4i.z = PV1i.w;
+PS0i = R4i.z;
+// 13
+R1i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(PV0i.x),-(intBitsToFloat(PV0i.w))) + 1.0));
+R10i.y = R9i.z;
+R6i.z = R16i.x;
+R9i.w = floatBitsToInt(min(intBitsToFloat(PV0i.z), 1.0));
+R0i.x = R11i.w;
+PS1i = R0i.x;
+}
+if( activeMaskStackC[3] == true ) {
+R1i.xyz = floatBitsToInt(texture(textureUnitVS8, intBitsToFloat(R1i.xy)).xyz);
+R12i.xyzw = floatBitsToInt(texture(textureUnitVS13, intBitsToFloat(R12i.zy)).xyzw);
+}
+if( activeMaskStackC[3] == true ) {
+// 0
+R125i.x = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.y), intBitsToFloat(R9i.w)));
+PV0i.x = R125i.x;
+R125i.y = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.x), intBitsToFloat(R9i.w)));
+R124i.z = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R1i.z), intBitsToFloat(R9i.w)));
+R9i.w = ((R5i.x == 0)?(R15i.z):(R15i.z));
+R1i.z = ((R5i.x == 0)?(R6i.y):(R6i.y));
+PS0i = R1i.z;
+// 1
+R1i.x = ((R5i.x == 0)?(0):(0x3f800000));
+R1i.y = ((R5i.x == 0)?(R20i.z):(R20i.z));
+R126i.z = ((R5i.x == 0)?(0):(PV0i.x));
+R2i.w = ((R5i.x == 0)?(R3i.x):(R2i.x));
+R126i.y = ((R5i.x == 0)?(0):(R9i.y));
+PS1i = R126i.y;
+// 2
+R123i.x = ((R5i.x == 0)?(0):(R125i.y));
+PV0i.x = R123i.x;
+R124i.y = ((R5i.x == 0)?(0):(R12i.w));
+R123i.z = ((R5i.x == 0)?(0):(R15i.x));
+PV0i.z = R123i.z;
+R123i.w = ((R5i.x == 0)?(0):(R3i.z));
+PV0i.w = R123i.w;
+R127i.y = ((R5i.x == 0)?(0):(R124i.z));
+PS0i = R127i.y;
+// 3
+R21i.x = ((R1i.x == 0)?(R3i.z):(PV0i.w));
+R21i.y = ((R1i.x == 0)?(R15i.x):(PV0i.z));
+R21i.z = ((R1i.x == 0)?(R9i.y):(R126i.y));
+R123i.w = ((R5i.x == 0)?(0):(R4i.z));
+PV1i.w = R123i.w;
+R22i.x = ((R1i.x == 0)?(R125i.y):(PV0i.x));
+PS1i = R22i.x;
+// 4
+backupReg0i = R125i.x;
+R125i.x = R11i.w;
+R22i.y = ((R1i.x == 0)?(backupReg0i):(R126i.z));
+R22i.z = ((R1i.x == 0)?(R124i.z):(R127i.y));
+R22i.w = ((R1i.x == 0)?(R4i.z):(PV1i.w));
+// 5
+R123i.x = ((R5i.x == 0)?(0):(R4i.x));
+PV1i.x = R123i.x;
+R127i.y = ((R5i.x == 0)?(0):(R12i.z));
+R126i.z = ((R5i.x == 0)?(0):(R12i.y));
+R125i.w = ((R5i.x == 0)?(0):(R10i.y));
+R9i.y = ((R5i.x == 0)?(0):(R6i.z));
+PS1i = R9i.y;
+// 6
+R126i.x = ((R5i.x == 0)?(0):(R0i.w));
+R125i.y = ((R5i.x == 0)?(0):(R24i.z));
+R124i.z = ((R5i.x == 0)?(0):(R2i.y));
+R21i.w = ((R1i.x == 0)?(R4i.x):(PV1i.x));
+R124i.w = ((R5i.x == 0)?(0):(R8i.y));
+PS0i = R124i.w;
+// 7
+R124i.x = ((R5i.x == 0)?(0):(R7i.y));
+R126i.y = ((R5i.x == 0)?(0):(R5i.z));
+R125i.z = ((R5i.x == 0)?(0):(R13i.w));
+R123i.w = ((R5i.x == 0)?(0):(R12i.x));
+PV1i.w = R123i.w;
+R127i.z = ((R5i.x == 0)?(0):(R2i.z));
+PS1i = R127i.z;
+// 8
+R23i.x = ((R1i.x == 0)?(R12i.x):(PV1i.w));
+R23i.y = ((R1i.x == 0)?(R12i.y):(R126i.z));
+R23i.z = ((R1i.x == 0)?(R12i.z):(R127i.y));
+R23i.w = ((R1i.x == 0)?(R12i.w):(R124i.y));
+R127i.x = R9i.z;
+PS0i = R127i.x;
+// 9
+R12i.x = ((R5i.x == 0)?(R20i.y):(R6i.y));
+R127i.y = ((R5i.x == 0)?(0):(R14i.w));
+R126i.z = ((R5i.x == 0)?(R20i.z):(R20i.z));
+R123i.w = ((R5i.x == 0)?(0):(R0i.x));
+PV1i.w = R123i.w;
+R9i.z = ((R5i.x == 0)?(0):(R16i.z));
+PS1i = R9i.z;
+// 10
+R25i.x = ((R1i.x == 0)?(R125i.x):(PV1i.w));
+R25i.y = ((R1i.x == 0)?(R127i.x):(R125i.w));
+// 11
+R127i.x = ((R5i.x == 0)?(0):(R11i.y));
+R124i.y = ((R5i.x == 0)?(0):(R15i.w));
+R12i.z = ((R5i.x == 0)?(0):(R17i.z));
+R123i.w = ((R5i.x == 0)?(0):(R24i.x));
+PV1i.w = R123i.w;
+R12i.w = ((R5i.x == 0)?(0):(R13i.y));
+PS1i = R12i.w;
+// 12
+R6i.x = ((R1i.x == 0)?(R24i.x):(PV1i.w));
+R6i.y = ((R1i.x == 0)?(R2i.y):(R124i.z));
+R4i.z = ((R5i.x == 0)?(0):(R16i.w));
+R125i.w = ((R5i.x == 0)?(0):(R3i.y));
+R126i.w = ((R5i.x == 0)?(0):(R14i.w));
+PS0i = R126i.w;
+// 13
+backupReg0i = R4i.w;
+R123i.x = ((R5i.x == 0)?(0):(R13i.x));
+PV1i.x = R123i.x;
+R123i.y = ((R5i.x == 0)?(0):(R0i.z));
+PV1i.y = R123i.y;
+R124i.z = ((R5i.x == 0)?(0):(R0i.y));
+R127i.w = ((R5i.x == 0)?(R19i.y):(R8i.w));
+R4i.w = ((R5i.x == 0)?(R19i.z):(backupReg0i));
+PS1i = R4i.w;
+// 14
+R24i.x = ((R1i.x == 0)?(R13i.x):(PV1i.x));
+R24i.y = ((R1i.x == 0)?(R8i.y):(R124i.w));
+R24i.z = ((R1i.x == 0)?(R13i.w):(R125i.z));
+PV0i.z = R24i.z;
+R24i.w = ((R1i.x == 0)?(R5i.z):(R126i.y));
+R0i.x = ((R1i.x == 0)?(R0i.z):(PV1i.y));
+PS0i = R0i.x;
+// 15
+backupReg0i = R0i.y;
+PV1i.x = R16i.x;
+R0i.y = ((R1i.x == 0)?(R3i.y):(R125i.w));
+R0i.z = ((R1i.x == 0)?(R14i.w):(R126i.w));
+R0i.w = ((R1i.x == 0)?(backupReg0i):(R124i.z));
+R6i.z = ((R1i.x == 0)?(PV0i.z):(R125i.y));
+PS1i = R6i.z;
+// 16
+R123i.x = ((R5i.x == 0)?(R19i.w):(R15i.z));
+PV0i.x = R123i.x;
+R123i.y = ((R5i.x == 0)?(R19i.x):(R5i.w));
+PV0i.y = R123i.y;
+R25i.z = ((R1i.x == 0)?(PV1i.x):(R9i.y));
+// 17
+R19i.x = ((R1i.x == 0)?(R5i.y):(PV0i.y));
+R19i.y = ((R1i.x == 0)?(R4i.y):(R127i.w));
+R19i.z = ((R1i.x == 0)?(R7i.z):(R4i.w));
+R19i.w = ((R1i.x == 0)?(R9i.w):(PV0i.x));
+R25i.w = ((R1i.x == 0)?(R126i.x):(R126i.x));
+PS1i = R25i.w;
+// 18
+R123i.x = ((R5i.x == 0)?(0):(R14i.x));
+PV0i.x = R123i.x;
+// 19
+backupReg0i = R14i.x;
+backupReg1i = R14i.w;
+R14i.x = ((R1i.x == 0)?(backupReg0i):(PV0i.x));
+R14i.y = ((R1i.x == 0)?(R7i.y):(R124i.x));
+R14i.z = ((R1i.x == 0)?(R2i.z):(R127i.z));
+R14i.w = ((R1i.x == 0)?(backupReg1i):(R127i.y));
+// 20
+R123i.x = ((R5i.x == 0)?(R20i.x):(R2i.x));
+PV0i.x = R123i.x;
+// 21
+R20i.x = ((R1i.x == 0)?(R2i.w):(PV0i.x));
+R20i.y = ((R1i.x == 0)?(R1i.z):(R12i.x));
+R20i.z = ((R1i.x == 0)?(R1i.y):(R126i.z));
+// 22
+R123i.y = ((R5i.x == 0)?(0):(R17i.x));
+PV0i.y = R123i.y;
+// 23
+R15i.x = ((R1i.x == 0)?(R17i.x):(PV0i.y));
+R15i.y = ((R1i.x == 0)?(R11i.y):(R127i.x));
+R15i.z = ((R1i.x == 0)?(R15i.w):(R124i.y));
+R15i.w = ((R1i.x == 0)?(R16i.z):(R9i.z));
+// 24
+R123i.y = ((R5i.x == 0)?(0):(R18i.x));
+PV0i.y = R123i.y;
+// 25
+backupReg0i = R13i.y;
+R13i.x = ((R1i.x == 0)?(R18i.x):(PV0i.y));
+R13i.y = ((R1i.x == 0)?(R17i.z):(R12i.z));
+R13i.z = ((R1i.x == 0)?(backupReg0i):(R12i.w));
+R13i.w = ((R1i.x == 0)?(R16i.w):(R4i.z));
+}
+activeMaskStackC[1] = activeMaskStack[0] == true && activeMaskStackC[0] == true;
+// export
+gl_Position = vec4(intBitsToFloat(R19i.x), intBitsToFloat(R19i.y), intBitsToFloat(R19i.z), intBitsToFloat(R19i.w));
+// export
+passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+// export
+passParameterSem1 = vec4(intBitsToFloat(R13i.x), intBitsToFloat(R13i.y), intBitsToFloat(R13i.z), intBitsToFloat(R13i.w));
+// export
+passParameterSem3 = vec4(intBitsToFloat(R15i.x), intBitsToFloat(R15i.y), intBitsToFloat(R15i.z), intBitsToFloat(R15i.w));
+// export
+passParameterSem5 = vec4(intBitsToFloat(R14i.x), intBitsToFloat(R14i.y), intBitsToFloat(R14i.z), intBitsToFloat(R14i.w));
+// export
+passParameterSem8 = vec4(intBitsToFloat(R24i.x), intBitsToFloat(R24i.y), intBitsToFloat(R24i.z), intBitsToFloat(R24i.w));
+// export
+passParameterSem11 = vec4(intBitsToFloat(R25i.x), intBitsToFloat(R25i.y), intBitsToFloat(R25i.z), intBitsToFloat(R25i.w));
+// export
+passParameterSem14 = vec4(intBitsToFloat(R23i.x), intBitsToFloat(R23i.y), intBitsToFloat(R23i.z), intBitsToFloat(R23i.w));
+// export
+passParameterSem15 = vec4(intBitsToFloat(R22i.x), intBitsToFloat(R22i.y), intBitsToFloat(R22i.z), intBitsToFloat(R22i.w));
+// export
+passParameterSem16 = vec4(intBitsToFloat(R21i.x), intBitsToFloat(R21i.y), intBitsToFloat(R21i.z), intBitsToFloat(R21i.w));
+// export
+passParameterSem4 = vec4(intBitsToFloat(R20i.x), intBitsToFloat(R20i.y), intBitsToFloat(R20i.z), intBitsToFloat(R20i.z));
+// export
+passParameterSem9 = vec4(intBitsToFloat(R6i.x), intBitsToFloat(R6i.y), intBitsToFloat(R6i.z), intBitsToFloat(R6i.z));
+}


### PR DESCRIPTION
Also another smoke shader of BotW, report by Bleed.0xx on discord (only vertex, smoke itself seems to be only a texture).
![](https://cdn.discordapp.com/attachments/292733452590120961/366698133876637697/image.png)
The missing bloom shares the same root cause as BotW's bloom(when up depth), dof(when q-res 816 not scaled) and heatwave(when upscale half-res), according to Exzap, because the game creates a mipmap seperately so cemu won't auto rescale it.
Only added one to avoid the possibility of breaking other things, the rest 3 is then all handled by cemu (tested with 1440p)

before:
![no bloom](https://user-images.githubusercontent.com/21133512/31321705-63efbedc-acbc-11e7-9a3b-359352275fd4.PNG)
![no](https://user-images.githubusercontent.com/21133512/31321714-72a0217e-acbc-11e7-8640-70190f759fc2.PNG)
after:
![mip](https://user-images.githubusercontent.com/21133512/31321717-7ce775ce-acbc-11e7-903d-44517ef6643d.PNG)
![bloom](https://user-images.githubusercontent.com/21133512/31321729-9bc2cd90-acbc-11e7-9fac-fc5a5f9d3f01.png)

