### PR TITLE
Add modification packs for Xenoblade Chronicles X

### DIFF
--- a/Modifications/XCX_CollectiblesRange/patches.txt
+++ b/Modifications/XCX_CollectiblesRange/patches.txt
@@ -1,0 +1,59 @@
+[XCX_COLLECTIBLESRANGE] 
+moduleMatches = 0xF882D5CF
+
+codeCaveSize = 0xC0
+
+_itemRangeInner = 0x00000000
+0x00000000 = lis r5, 0x4250
+0x00000004 = addi r5, r5, 0x0000
+0x00000008 = stw r5, 0x4(r23)
+0x0000000C = lfs f10, 0x4(r23)
+0x00000010 = fadd f10, f9, f10
+0x00000014 = blr
+
+_itemHeightInner = 0x00000020
+0x00000020 = lis r5, 0x4250
+0x00000024 = addi r5, r5, 0x0000
+0x00000028 = stw r5, 0x4(r23)
+0x0000002C = lfs f12, 0x4(r23)
+0x00000030 = fadd f12, f10, f12
+0x00000034 = blr
+
+_itemRangeDoll = 0x00000040
+0x00000040 = lis r5, 0x4250
+0x00000044 = addi r5, r5, 0x0000
+0x00000048 = stw r5, 0x4(r23)
+0x0000004C = lfs f9, 0x4(r23)
+0x00000050 = fadd f9, f6, f9
+0x00000054 = blr
+
+_itemHeightDoll = 0x00000060
+0x00000060 = lis r5, 0x4250
+0x00000064 = addi r5, r5, 0x0000
+0x00000068 = stw r5, 0x4(r23)
+0x0000006C = lfs f10, 0x4(r23)
+0x00000070 = fadd f10, f7, f10
+0x00000074 = blr
+
+_itemRangeFlight = 0x00000080
+0x00000080 = lis r5, 0x4250
+0x00000084 = addi r5, r5, 0x0000
+0x00000088 = stw r5, 0x4(r23)
+0x0000008C = lfs f10, 0x4(r23)
+0x00000090 = fadd f10, f12, f10
+0x00000094 = blr
+
+_itemHeightFlight = 0x000000A0
+0x000000A0 = lis r5, 0x4250
+0x000000A4 = addi r5, r5, 0x0000
+0x000000A8 = stw r5, 0x4(r23)
+0x000000AC = lfs f0, 0x4(r23)
+0x000000B0 = fadd f0, f13, f0
+0x000000B4 = blr
+
+0x02389B80 = bla _itemRangeInner
+0x02389BB8 = bla _itemHeightInner
+0x02389C3C = bla _itemRangeDoll
+0x02389C74 = bla _itemHeightDoll
+0x02389CEC = bla _itemRangeFlight
+0x02389D30 = bla _itemHeightFlight

--- a/Modifications/XCX_CollectiblesRange/patches.txt
+++ b/Modifications/XCX_CollectiblesRange/patches.txt
@@ -1,5 +1,5 @@
 [XCX_COLLECTIBLESRANGE] 
-moduleMatches = 0xF882D5CF
+moduleMatches = 0xF882D5CF, 0x30B6E091, 0x218F6E07 ; 1.0.1E, 1.0.2U, 1.0.0U
 
 codeCaveSize = 0xC0
 

--- a/Modifications/XCX_CollectiblesRange/rules.txt
+++ b/Modifications/XCX_CollectiblesRange/rules.txt
@@ -1,0 +1,4 @@
+[Definition]
+titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
+name = "Xenoblade Chronicles X - Collectibles Range"
+version=2

--- a/Modifications/XCX_CustomDropRatio/patches.txt
+++ b/Modifications/XCX_CustomDropRatio/patches.txt
@@ -1,5 +1,5 @@
 [XCX_CUSTOMDROPRATIO]
-moduleMatches = 0xF882D5CF
+moduleMatches = 0xF882D5CF, 0x30B6E091, 0x218F6E07 ; 1.0.1E, 1.0.2U, 1.0.0U
 
 codeCaveSize = 0x20
 

--- a/Modifications/XCX_CustomDropRatio/patches.txt
+++ b/Modifications/XCX_CustomDropRatio/patches.txt
@@ -1,0 +1,21 @@
+[XCX_CUSTOMDROPRATIO]
+moduleMatches = 0xF882D5CF
+
+codeCaveSize = 0x20
+
+; Uncomment those TWO lines to affect the chest chance to appear
+0x021AADB8 = li r3, 3 ; 0 = no drop, 1 = always gold, 2 = always silver, 3 = always bronze
+0x021AADBC = blr
+
+_minDropRate = 0x00000000
+0x00000000 = cmpwi r31, 100 ; all items with drop ratio less than this value will have a new drop ratio set at line 0x00000010
+0x00000008 = blt .+0x8
+0x0000000C = b .+0x8
+0x00000010 = li r31, 100 ; new drop ratio
+0x00000014 = cmpw r3, r31
+0x00000018 = blr
+
+0x021AF5DC = bla _minDropRate ; modify drop ratio for gold chests
+0x021AF5F8 = bla _minDropRate ; modify drop ratio for silver chests
+0x021AF614 = bla _minDropRate ; modify drop ratio for bronze chests
+

--- a/Modifications/XCX_CustomDropRatio/patches.txt
+++ b/Modifications/XCX_CustomDropRatio/patches.txt
@@ -4,8 +4,8 @@ moduleMatches = 0xF882D5CF, 0x30B6E091, 0x218F6E07 ; 1.0.1E, 1.0.2U, 1.0.0U
 codeCaveSize = 0x20
 
 ; Uncomment those TWO lines to affect the chest chance to appear
-0x021AADB8 = li r3, 3 ; 0 = no drop, 1 = always gold, 2 = always silver, 3 = always bronze
-0x021AADBC = blr
+;0x021AADB8 = li r3, 3 ; 0 = no drop, 1 = always gold, 2 = always silver, 3 = always bronze
+;0x021AADBC = blr
 
 _minDropRate = 0x00000000
 0x00000000 = cmpwi r31, 100 ; all items with drop ratio less than this value will have a new drop ratio set at line 0x00000010

--- a/Modifications/XCX_CustomDropRatio/rules.txt
+++ b/Modifications/XCX_CustomDropRatio/rules.txt
@@ -1,0 +1,4 @@
+[Definition]
+titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
+name = "Xenoblade Chronicles X - Custom Drop Ratio"
+version=2


### PR DESCRIPTION
Add 2 new packs. One that increases collectibles range, other that allow customization of drop ratio for enemies loot.