### PR TITLE
[BotW] update contrasty, mainly add more tone mappings

### DIFF
--- a/Enhancement/BreathOfTheWild_Contrasty/bd8bba59e2149449_00000000000003c9_ps.txt
+++ b/Enhancement/BreathOfTheWild_Contrasty/bd8bba59e2149449_00000000000003c9_ps.txt
@@ -2,8 +2,11 @@
 #extension GL_ARB_texture_gather : enable
 // shader bd8bba59e2149449
 // Contrasty + Adjustable Bloom
-// Credit to bestminr for vibrance logic, and getdls
 // original shader dumped using cemu 1.10.0f, BotW 1.3.1
+
+
+#define tone_mapping 0
+//0 is game original, 1 is ACES Filmic, 2 is from SweetFX
 
 /*BloomFactor, gamma, exposure, vibrance and crushContrast can be modified */
 const float bloomFactor = 0.4; // 1.0 is neutral
@@ -17,6 +20,7 @@ const float crushContrast = 0.004; // 0.0 is neutral. Use small increments, loss
 const float floor = 16.0 / 255;
 const float scale = 255.0/(235.0-16.0);
 */
+
 
 uniform ivec4 uf_remappedPS[1];
 layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf46ac800 res 320x180x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x5) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
@@ -69,7 +73,7 @@ vec3 fColour = vec3(R126f.x, R127f.y, R126f.z);
 fColour = max(vec3(0.0), fColour - vec3(crushContrast));
 fColour = clamp(exposure * fColour, 0.0, 1.0);
 fColour = pow(fColour, vec3(1.0 / gamma));
-float luminance = fColour.r*0.299 + fColour.g*0.587 + fColour.b*0.114;
+float luminance = fColour.r*intBitsToFloat(0x3e99096c) + fColour.g*intBitsToFloat(0x3f162b6b) + fColour.b*intBitsToFloat(0x3dea4a8c);
 float mn = min(min(fColour.r, fColour.g), fColour.b);
 float mx = max(max(fColour.r, fColour.g), fColour.b);
 float sat = (1.0-(mx - mn)) * (1.0-mx) * luminance * 5.0;
@@ -78,12 +82,11 @@ vec3 lightness = vec3((mn + mx)/2.0);
 fColour = mix(fColour, mix(fColour, lightness, -vibrance), sat);
 //vec3 fColour = (fColour.xyz - floor) * scale;  // Not recommended 0-255->16-235..
 
+#if (tone_mapping == 0)
 R126f.x = fColour.x;
 R127f.y = fColour.y;
 R126f.z = fColour.z;
 PV0f.xyz = fColour;
-
-
 // 1
 tempf.x = dot(vec4(PV0f.x,PV0f.y,PV0f.z,-0.0),vec4(intBitsToFloat(0x3e99096c),intBitsToFloat(0x3f162b6b),intBitsToFloat(0x3dea4a8c),0.0));
 PV1f.x = tempf.x;
@@ -167,6 +170,39 @@ PV1f.w = R123f.w;
 R0f.x = (mul_nonIEEE(R126f.x,R125f.w) + PV1f.w);
 R0f.y = (mul_nonIEEE(R126f.x,R127f.z) + PV1f.w);
 R0f.z = (mul_nonIEEE(R126f.x,R126f.y) + PV1f.w);
+#endif
+
+#if (tone_mapping == 1)
+R0f.xyz = fColour * intBitsToFloat(0x3f2aaaab);
+R0f.xyz = (R0f.xyz*(2.51*R0f.xyz+0.03))/(R0f.xyz*(2.43*R0f.xyz+0.59)+0.14);
+R0f.xyz = clamp(R0f.xyz,0.0,1.0);
+#endif
+
+#if (tone_mapping == 2)
+
+//dummy
+const float Saturation = 0.00; // [-1.0 ~ 1.0] Saturates Colors
+const float Bleach = 0.0;
+
+vec3 color = fColour;
+color *= intBitsToFloat(0x3f2aaaab); // Exposure
+const vec3 coefLuma = vec3(intBitsToFloat(0x3e99096c),intBitsToFloat(0x3f162b6b),intBitsToFloat(0x3dea4a8c));
+float lum = dot(coefLuma, color);
+
+float L = clamp(10.0 * (lum - 0.45), 0.0, 1.0);
+vec3 A2 = Bleach * color;
+
+vec3 result1 = 2.0f * color * lum;
+vec3 result2 = 1.0f - 2.0f * (1.0f - lum) * (1.0f - color);
+
+vec3 newColor = mix(result1, result2, L);
+vec3 mixRGB = A2 * newColor;
+color += ((1.0f - A2) * mixRGB);
+
+vec3 middlegray = vec3(dot(color, vec3(1.0 / 3.0)));
+vec3 diffcolor = color - middlegray;
+R0f.xyz = (color + diffcolor * Saturation) / (1 + (diffcolor * Saturation)); // Saturation
+#endif
 
 // export
 passPixelColor0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);

--- a/Enhancement/BreathOfTheWild_Contrasty/rules.txt
+++ b/Enhancement/BreathOfTheWild_Contrasty/rules.txt
@@ -2,3 +2,12 @@
 titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = "The Legend of Zelda: Breath of the Wild - Color Tweak + Adjustable Bloom"
 version = 2
+
+# Credit: 
+# getdls for contrasty
+# bestminr for vibrance logic
+# kiri, navras for tone mapping
+# navras seperate contrasty from AARemoval
+
+# approximate ACES Flimic ~ https://knarkowicz.wordpress.com/2016/01/06/aces-filmic-tone-mapping-curve/
+# SweetFX Tone mapping by Christian Cann Schuldt Jensen ~ CeeJay.dk


### PR DESCRIPTION
Also move credits to rules.txt, they're too much

Game original tone mapping is fine (also I can't understand it xD), but it partially causes what ppl might say "washed out".
So added another two for toggling, one is simplified ACES Filmic, which over-saturates also gives a 'film look', another is from kiri, who ripped the one in SweetFX into Clarity pack.