### PR TITLE
Add ClarityGFX pages via submodule, update some text.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_clarity"]
+	path = _clarity
+	url = https://github.com/MelonSpeedruns/ClarityGFX_Presets

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,10 @@
 theme: jekyll-theme-midnight
 show_downloads: true
+
+
+# Clarity Page
+data_dir: _clarity/_data
+# Collections
+collections:
+  clarity:
+    output: true

--- a/index.md
+++ b/index.md
@@ -1,14 +1,18 @@
 ### **Download Instructions**  
 
-Only download the graphic packs from the buttons above. Please delete the old ones first before adding in the new ones.
+Only download the graphic packs from the buttons above which should come in a zip. Please delete the old ones first before adding in the new ones.
+Simply placing the folders from the extracted zip in Cemu's `graphicPacks` folder should work.
+Be sure to enable the graphic packs you want in the graphic packs menu which can be found in `Options->Graphic packs`.
 
-**Missing the resolution packs on this Github? That's because we now automatically build the resolution packs. Follow the download instructions to download them for all the supported resolutions.**
-
+Having the graphic packs for e.g. Splatoon enabled won't affect Breath of the Wild (seen by the Active row in the options when the game is launched).
 
 For Breath of the Wild specific help, please refer to [this FAQ](https://{{site.github.owner_name}}.github.io/cemu_graphic_packs/botw). For other games see ['I need help'](#i-need-help).
 ##### Keep in mind that all of these graphic packs are a work in progress.  
 ##### If there's a resolution missing it's because it was done on purpose and the game natively runs on that resolution.  
 ##### If you want Graphic Packs for < Cemu 1.8.0 you need to use legacy packs, which you can download [here](https://github.com/slashiee/cemu_graphic_packs/releases/download/1/graphicPacks.zip).
+
+### **Browse Clarity Presets**
+Want to see what all the presets look like? [Check it out!](https://{{site.github.owner_name}}.github.io/cemu_graphic_packs/clarity)
 
 ### **Games with Graphic Packs**
 


### PR DESCRIPTION
The clarity pages work via submodules which will be updated at and mostly by [MelonSpeedruns repository](https://github.com/MelonSpeedruns/ClarityGFX_Presets) which will then listen to pull requests etc. The url will still belong to this repository, so https://slashiee.github.io/cemu_graphic_packs/clarity/. One minor point is that to retrieve his latest updates, you need to update the submodule via a console with the command `git submodule update --remote --merge` in the github branch. I'll try to take care of this whenever there's an update.

Due to the _data setup it's really easy to add Presets (https://github.com/MelonSpeedruns/ClarityGFX_Presets/blob/master/_data/presets.yml). The photo's can be clicked on to get a magnified look at it. Also, it doesn't have to be game exclusive, it's all placeholders for now. There's also support for multiple pictures in the form of the image slider, but currently we just have used 4 dublicate links.

The website can be previewed at https://crementif.github.io/cemu_graphic_packs/clarity/ .