### PR TITLE
Add EUR version to rules.txt for Pokken

### DIFF
--- a/Enhancement/Pokken_HighResShadows/rules.txt
+++ b/Enhancement/Pokken_HighResShadows/rules.txt
@@ -1,5 +1,5 @@
 [Definition]
-titleIds = 00050000101DF400,00050002101DF401
+titleIds = 00050000101DF400,00050002101DF401,00050000101DF500
 name = "Pokken Tournament - High Res Shadows"
 version = 2
 

--- a/Source/PokkenTournament/rules.txt
+++ b/Source/PokkenTournament/rules.txt
@@ -8,7 +8,7 @@ $scaleFactorY = $fullHeight / 720.0;
 $title = get_title($fullWidth, $fullHeight);
 ?>
 [Definition]
-titleIds = 00050000101DF400,00050002101DF401
+titleIds = 00050000101DF400,00050002101DF401,0050000101DF500
 name = "Pokken Tournament - <?=$title?>"
 version = 2
 


### PR DESCRIPTION
The graphic pack is being enabled only for USA and DEMO version. Add EUR version 00050000101DF500