### PR TITLE
[SM3Dworld] Fix for the touch position in ultrawide resolution

### DIFF
--- a/Source/SuperMario3DWorld/patches.txt
+++ b/Source/SuperMario3DWorld/patches.txt
@@ -19,3 +19,7 @@ _aspectAddr = 0x10363ED4
 # Aspect calculation
 0x0241D9B4 = lis r8, _aspectAddr@ha
 0x0241D9B8 = lfs f0, _aspectAddr@l(r8)
+
+# touch position fix
+0x0241D9D4 = lis r8, _aspectAddr@ha
+0x0241D9D8 = lfs f0, _aspectAddr@l(r8)


### PR DESCRIPTION
Touching the screen when using ultrawide touches the wrong position, this makes sure the position is correct.

Credits: Xalphenos