### PR TITLE
[HW] Typos in the normal resolution file

### DIFF
--- a/Source/HyruleWarriors/rules.txt
+++ b/Source/HyruleWarriors/rules.txt
@@ -75,26 +75,26 @@ overwriteHeight = <?=round($scaleFactorY*90)?>
 width = 64
 height = 64
 formats = 0x005
-#overwriteWidth = <?=round($scaleFactorY*64)?> 
+#overwriteWidth = <?=round($scaleFactorX*64)?> 
 #overwriteHeight = <?=round($scaleFactorY*64)?> 
 
 [TextureRedefine] #Dupe of Main Game?
 width = 16
 height = 16
 formats = 0x005
-#overwriteWidth = <?=round($scaleFactorY*16)?> 
+#overwriteWidth = <?=round($scaleFactorX*16)?> 
 #overwriteHeight = <?=round($scaleFactorY*16)?> 
 
 [TextureRedefine] #Dupe of Main Game?
 width = 4
 height = 4
 formats = 0x005
-#overwriteWidth = <?=round($scaleFactorY*6)?> 
+#overwriteWidth = <?=round($scaleFactorX*6)?> 
 #overwriteHeight = <?=round($scaleFactorY*6)?> 
 
 [TextureRedefine] #Dupe of Main Game?
 width = 1
 height = 1
 formats = 0x005
-#overwriteWidth = <?=round($scaleFactorY*1)?> 
+#overwriteWidth = <?=round($scaleFactorX*1)?> 
 #overwriteHeight = <?=round($scaleFactorY*1)?> 


### PR DESCRIPTION
Fix some errors in the normal resolution file, that are affecting the ultrawide modes. 
The original file uses scaleFactorY for width which shouldn't matter for normal scaling but makes some different values when using non-16:9 proportion.