### PR TITLE
[HW] Add support for JP release

### DIFF
--- a/Enhancement/HyruleWarriors_HighResShadows/rules.txt
+++ b/Enhancement/HyruleWarriors_HighResShadows/rules.txt
@@ -1,6 +1,5 @@
 [Definition]
-titleIds = 000500001017D800,000500001017D900
-
+titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = "Hyrule Warriors - Higher Quality Shadows"
 version = 2
 

--- a/Modifications/HyruleWarriors_60FPS/rules.txt
+++ b/Modifications/HyruleWarriors_60FPS/rules.txt
@@ -1,4 +1,4 @@
 [Definition]
-titleIds = 000500001017D800,000500001017D900
+titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = "Hyrule Warriors - 60FPS Fixes (requires stable 60FPS!)"
 version = 2

--- a/Workaround/HyruleWarriors_30FPS/rules.txt
+++ b/Workaround/HyruleWarriors_30FPS/rules.txt
@@ -1,5 +1,5 @@
 [Definition]
-titleIds = 000500001017D800,000500001017D900
+titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = "Hyrule Warriors - 30FPS Lock"
 version = 2
 

--- a/Workaround/HyruleWarriors_DLCFix/rules.txt
+++ b/Workaround/HyruleWarriors_DLCFix/rules.txt
@@ -1,4 +1,4 @@
 [Definition]
-titleIds = 000500001017D800,000500001017D900
+titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = "Hyrule Warriors - DLC Fix"
 version = 2

--- a/Workaround/HyruleWarriors_DoFBlurRemoval/rules.txt
+++ b/Workaround/HyruleWarriors_DoFBlurRemoval/rules.txt
@@ -1,4 +1,4 @@
 [Definition]
-titleIds = 000500001017D800,000500001017D900
+titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = "Hyrule Warriors - DoF Blur Removal"
 version = 2

--- a/Workaround/HyruleWarriors_EnemyDeathFix/rules.txt
+++ b/Workaround/HyruleWarriors_EnemyDeathFix/rules.txt
@@ -1,4 +1,4 @@
 [Definition]
-titleIds = 000500001017D800,000500001017D900
+titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = "Hyrule Warriors - NVIDIA Enemy Death Fix"
 version = 2

--- a/Workaround/HyruleWarriors_ShadowRemoval/rules.txt
+++ b/Workaround/HyruleWarriors_ShadowRemoval/rules.txt
@@ -1,4 +1,4 @@
 [Definition]
-titleIds = 000500001017D800,000500001017D900
+titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = "Hyrule Warriors - Shadow Removal"
 version = 2


### PR DESCRIPTION
JP v272 RPX matches EU/US v208, all patches seem to work fine on it too.