### PR TITLE
Fix for the physics of Arrow projectiles

### DIFF
--- a/Source/BreathOfTheWild_StaticFPS/patches.txt
+++ b/Source/BreathOfTheWild_StaticFPS/patches.txt
@@ -1,6 +1,8 @@
 <?php
 $targetfps = $argv[1];
-$divisor = 30/$targetfps
+$divisor = 30/$targetfps;
+$derivative1 = 30*$divisor;
+$derivative2 = 0.5/$divisor;
 ?>
 [BotwFPSV208] #i.e. v1.5.0
 moduleMatches = 0x6267BFD0
@@ -12,6 +14,10 @@ _divisor = 0x0 # edit the next line to change the divisor
 0x00000000 = .float <?=$divisor?> # = 30FPS / TARGET FPS, e.g. 30FPS / 18FPS = 1.66667
 _targetfps = 0x18 # edit the next line to change the target fps
 0x18 = .float <?=$targetfps?> 
+
+#Arrows by Epigramx
+0x1001CCAC = .float <?=$derivative1?> # = 30 * divisor 
+0x1001CB18 = .float <?=$derivative2?> # = 0.5 / divisor
 
 #"Best fence" by Rajkosto
 _fenceNeg1 = 0x00000004
@@ -67,6 +73,10 @@ _divisor = 0x0 # edit the next line to change the divisor
 0x00000000 = .float <?=$divisor?> # = 30FPS / TARGET FPS, e.g. 30FPS / 18FPS = 1.66667
 _targetfps = 0x18 # edit the next line to change the target fps
 0x18 = .float <?=$targetfps?> 
+
+#Arrows by Epigramx
+0x1001CCAC = .float <?=$derivative1?> # = 30 * divisor 
+0x1001CB18 = .float <?=$derivative2?> # = 0.5 / divisor
 
 #"Best fence" by Rajkosto
 _fenceNeg1 = 0x00000004

--- a/Source/BreathOfTheWild_StaticFPS/readme.txt
+++ b/Source/BreathOfTheWild_StaticFPS/readme.txt
@@ -5,7 +5,8 @@ when Link paraglides; the caveat is that the user must pick a target FPS that
 they can maintain.
 
 It improves over previous static mods in that it allows ANY value as a
-static fps target and it includes the stamina fix.
+static fps target and it includes the stamina fix. Now it also features a fix
+for the physics of arrow projectiles.
 
 To use it simply grab one of the provided versions or edit one with these
 changes: a) rules.txt frequency and name b) divide 30 by the target FPS c) use


### PR DESCRIPTION
This fixes the infamous arrow distance bug at !=30FPS by changing two relevant floats accordingly (and the comments include how the calculation is done). It's a product of trial and error, basic ideas and some luck.

The current patch applies to the static FPS mod. FPS++ will be likely fixed by Xalphenos.