### PR TITLE
[Hyrule Warriors] Fixed coop-gamepad resolution

### DIFF
--- a/Source/HyruleWarriors/rules.txt
+++ b/Source/HyruleWarriors/rules.txt
@@ -34,7 +34,7 @@ overwriteHeight = <?=round($scaleFactorY*720)?>
 
 [TextureRedefine] #Gamepad (Co-Op)
 width = 648
-height = 368
+height = 360
 overwriteWidth = <?=round($scaleFactorX*1280)?> 
 overwriteHeight = <?=round($scaleFactorY*720)?> 
 


### PR DESCRIPTION
Changed the height amount, as it was set to the wrong value.
Now the game properly renders the gamepad screen at the desired resolution.

[Before image](https://i.imgur.com/jcYOfDT.jpg)
[After image](https://i.imgur.com/5BlHqHc.jpg)