### PR TITLE
Fixed 8x8 Texture redefine in Bayonetta 1 Res pack

### DIFF
--- a/Source/Bayonetta_Resolution/rules.txt
+++ b/Source/Bayonetta_Resolution/rules.txt
@@ -59,7 +59,7 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2160
+name = 3840x2160 4K
 $width = 3840
 $height = 2160
 $gameWidth = 1280
@@ -163,6 +163,6 @@ overwriteHeight  = ($height/$gameHeight) * 16
 [TextureRedefine] #
 width = 8
 height = 8
-formatsExcluded = 
+formats = 0x001a
 overwriteWidth = ($width/$gameWidth) * 8
 overwriteHeight = ($height/$gameHeight) * 8


### PR DESCRIPTION
Changed the format section of the texture redefine from "formatsExcluded =" to "formats = 0x001a" allowing the game to boot again with the res pack enabled.

As a side note I did not see any other texture formats using 8x8 resolution besides 0x001a