### PR TITLE
fixing some stuff

### DIFF
--- a/Source/AmiiboFestival_Resolution/rules.txt
+++ b/Source/AmiiboFestival_Resolution/rules.txt
@@ -1,0 +1,129 @@
+[Definition]
+titleIds = 00050000101C6400,00050000101C6500,0005000010190100
+name = Resolution
+path = "Animal Crossing: amiibo Festival/Graphics/Resolution"
+description = Changes the resolution of the game.
+version = 3
+
+[Preset]
+name = 1280x720 (Default)
+$width = 1280
+$height = 720
+$gameWidth = 1280
+$gameHeight = 720
+
+// Performance
+
+[Preset]
+name = 320x180
+$width = 320
+$height = 180
+$gameWidth = 1280
+$gameHeight = 720
+
+[Preset]
+name = 640x360
+$width = 640
+$height = 360
+$gameWidth = 1280
+$gameHeight = 720
+
+[Preset]
+name = 960x540
+$width = 960
+$height = 540
+$gameWidth = 1280
+$gameHeight = 720
+
+// Common HD Resolutions
+
+[Preset]
+name = 1920x1080
+$width = 1920
+$height = 1080
+$gameWidth = 1280
+$gameHeight = 720
+
+[Preset]
+name = 2560x1440
+$width = 2560
+$height = 1440
+$gameWidth = 1280
+$gameHeight = 720
+
+[Preset]
+name = 3200x1800
+$width = 3200
+$height = 1800
+$gameWidth = 1280
+$gameHeight = 720
+
+[Preset]
+name = 3840x2160
+$width = 3840
+$height = 2160
+$gameWidth = 1280
+$gameHeight = 720
+
+[Preset]
+name = 5120x2880
+$width = 5120
+$height = 2880
+$gameWidth = 1280
+$gameHeight = 720
+
+[TextureRedefine]
+width = 1280
+height = 720
+tileModesExcluded = 0x001
+overwriteWidth = ($width/$gameWidth) * 1280
+overwriteHeight = ($height/$gameHeight) * 720 
+
+[TextureRedefine]
+width = 854
+height = 480
+#formatsExcluded = 
+overwriteWidth = ($width/$gameWidth) * 854
+overwriteHeight = ($height/$gameHeight) * 480
+
+[TextureRedefine]
+width = 800
+height = 250
+#formatsExcluded = 
+overwriteWidth = ($width/$gameWidth) * 800
+overwriteHeight = ($height/$gameHeight) * 250
+
+[TextureRedefine]
+width = 640
+height = 360
+tileModesExcluded = 0x001
+overwriteWidth = ($width/$gameWidth) * 640
+overwriteHeight = ($height/$gameHeight) * 360
+
+[TextureRedefine]
+width = 320
+height = 180
+#formatsExcluded = 
+overwriteWidth = ($width/$gameWidth) * 320
+overwriteHeight = ($height/$gameHeight) * 180
+
+[TextureRedefine]
+width = 160
+height = 90
+#formatsExcluded = 
+overwriteWidth = ($width/$gameWidth) * 160
+overwriteHeight = ($height/$gameHeight) * 90
+
+[TextureRedefine]
+width = 80
+height = 45
+#formatsExcluded = 
+overwriteWidth = ($width/$gameWidth) * 80
+overwriteHeight = ($height/$gameHeight) * 45
+
+[TextureRedefine]
+width = 40
+height = 22
+#formatsExcluded = 
+overwriteWidth = ($width/$gameWidth) * 40
+overwriteHeight = ($height/$gameHeight) * 22

--- a/Source/BreathOfTheWild_Resolution/rules.txt
+++ b/Source/BreathOfTheWild_Resolution/rules.txt
@@ -72,8 +72,6 @@ $height = 2880
 $gameWidth = 1280
 $gameHeight = 720
 
-//// THE FOLLOWING REQUIRE A GAME PATCH (patches.txt) FOR CUSTOM ASPECT RATIOS ////
-
 // Common Ultrawide Resolutions
 
 [Preset]

--- a/Source/BreathOfTheWild_Resolution/rules.txt
+++ b/Source/BreathOfTheWild_Resolution/rules.txt
@@ -72,6 +72,8 @@ $height = 2880
 $gameWidth = 1280
 $gameHeight = 720
 
+//// THE FOLLOWING REQUIRE A GAME PATCH (patches.txt) FOR CUSTOM ASPECT RATIOS ////
+
 // Common Ultrawide Resolutions
 
 [Preset]
@@ -88,40 +90,33 @@ $height = 1440
 $gameWidth = 1280
 $gameHeight = 720
 
-[Preset]
-name = 4300x1800 ("21:9")
-$width = 4300
-$height = 1800
-$gameWidth = 1280
-$gameHeight = 720
-
 // Common 16:10 Resolutions
 
 [Preset]
 name = 1440x936 (16:10)
 $width = 1440
-$height = 936 // 720x1.3
+$height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 1680x1080 (16:10)
 $width = 1680
-$height = 1080 // 720x1.5
+$height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 1920x1224 (16:10)
 $width = 1920
-$height = 1224 // 720x1.7
+$height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 2560x1656 (16:10)
 $width = 2560
-$height = 1656 // 720x2.3
+$height = 1584 // 720x2.2
 $gameWidth = 1280
 $gameHeight = 720
 
@@ -133,16 +128,16 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2448 (16:10)
+name = 3840x2412 (16:10)
 $width = 3840
-$height = 2448 // 720x3.4
+$height = 2412 // 720x3.35
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 5120x3168 (16:10)
 $width = 5120
-$height = 3168 // 720x4.4
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 

--- a/Source/BreathOfTheWild_Resolution/rules.txt
+++ b/Source/BreathOfTheWild_Resolution/rules.txt
@@ -91,28 +91,28 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x900 (16:10)
 $width = 1440
 $height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1044 (16:10)
 $width = 1680
 $height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
 $height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1584 (16:10)
 $width = 2560
 $height = 1584 // 720x2.2
 $gameWidth = 1280
@@ -133,7 +133,7 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3168 (16:10)
+name = 5120x3204 (16:10)
 $width = 5120
 $height = 3204 // 720x4.45
 $gameWidth = 1280

--- a/Source/CaptainToad_Resolution/rules.txt
+++ b/Source/CaptainToad_Resolution/rules.txt
@@ -91,28 +91,28 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x900 (16:10)
 $width = 1440
 $height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1044 (16:10)
 $width = 1680
 $height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
 $height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1584 (16:10)
 $width = 2560
 $height = 1584 // 720x2.2
 $gameWidth = 1280
@@ -133,7 +133,7 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3168 (16:10)
+name = 5120x3204 (16:10)
 $width = 5120
 $height = 3204 // 720x4.45
 $gameWidth = 1280

--- a/Source/CaptainToad_Resolution/rules.txt
+++ b/Source/CaptainToad_Resolution/rules.txt
@@ -91,51 +91,51 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x900 (16:10)
+name = 1440x936 (16:10)
 $width = 1440
-$height = 900
+$height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1050 (16:10)
+name = 1680x1080 (16:10)
 $width = 1680
-$height = 1050
+$height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1200 (16:10)
+name = 1920x1224 (16:10)
 $width = 1920
-$height = 1200
+$height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1600 (16:10)
+name = 2560x1656 (16:10)
 $width = 2560
-$height = 1600
+$height = 1584 // 720x2.2
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 2880x1800 (16:10)
 $width = 2880
-$height = 1800
+$height = 1800 // 720x2.5
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2400 (16:10)
+name = 3840x2412 (16:10)
 $width = 3840
-$height = 2400
+$height = 2412 // 720x3.35
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3200 (16:10)
+name = 5120x3168 (16:10)
 $width = 5120
-$height = 3200
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 

--- a/Source/MarioKart8_Resolution/rules.txt
+++ b/Source/MarioKart8_Resolution/rules.txt
@@ -93,28 +93,28 @@ $gameHeight = 720
 [Preset]
 name = 1440x936 (16:10)
 $width = 1440
-$height = 936 // 720x1.3
+$height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 1680x1080 (16:10)
 $width = 1680
-$height = 1080 // 720x1.5
+$height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 1920x1224 (16:10)
 $width = 1920
-$height = 1224 // 720x1.7
+$height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 2560x1656 (16:10)
 $width = 2560
-$height = 1656 // 720x2.3
+$height = 1584 // 720x2.2
 $gameWidth = 1280
 $gameHeight = 720
 
@@ -126,16 +126,16 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2448 (16:10)
+name = 3840x2412 (16:10)
 $width = 3840
-$height = 2448 // 720x3.4
+$height = 2412 // 720x3.35
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 5120x3168 (16:10)
 $width = 5120
-$height = 3168 // 720x4.4
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 

--- a/Source/MarioKart8_Resolution/rules.txt
+++ b/Source/MarioKart8_Resolution/rules.txt
@@ -91,28 +91,28 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x900 (16:10)
 $width = 1440
 $height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1044 (16:10)
 $width = 1680
 $height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
 $height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1584 (16:10)
 $width = 2560
 $height = 1584 // 720x2.2
 $gameWidth = 1280
@@ -129,6 +129,13 @@ $gameHeight = 720
 name = 3840x2412 (16:10)
 $width = 3840
 $height = 2412 // 720x3.35
+$gameWidth = 1280
+$gameHeight = 720
+
+[Preset]
+name = 5120x3204 (16:10)
+$width = 5120
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 

--- a/Source/Splatoon_Resolution/rules.txt
+++ b/Source/Splatoon_Resolution/rules.txt
@@ -91,28 +91,28 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x900 (16:10)
 $width = 1440
 $height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1044 (16:10)
 $width = 1680
 $height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
 $height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1584 (16:10)
 $width = 2560
 $height = 1584 // 720x2.2
 $gameWidth = 1280
@@ -133,7 +133,7 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3168 (16:10)
+name = 5120x3204 (16:10)
 $width = 5120
 $height = 3204 // 720x4.45
 $gameWidth = 1280

--- a/Source/Splatoon_Resolution/rules.txt
+++ b/Source/Splatoon_Resolution/rules.txt
@@ -91,51 +91,51 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x900 (16:10)
+name = 1440x936 (16:10)
 $width = 1440
-$height = 900
+$height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1050 (16:10)
+name = 1680x1080 (16:10)
 $width = 1680
-$height = 1050
+$height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1200 (16:10)
+name = 1920x1224 (16:10)
 $width = 1920
-$height = 1200
+$height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1600 (16:10)
+name = 2560x1656 (16:10)
 $width = 2560
-$height = 1600
+$height = 1584 // 720x2.2
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 2880x1800 (16:10)
 $width = 2880
-$height = 1800
+$height = 1800 // 720x2.5
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2400 (16:10)
+name = 3840x2412 (16:10)
 $width = 3840
-$height = 2400
+$height = 2412 // 720x3.35
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3200 (16:10)
+name = 5120x3168 (16:10)
 $width = 5120
-$height = 3200
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 

--- a/Source/SuperMario3DWorld_Resolution/rules.txt
+++ b/Source/SuperMario3DWorld_Resolution/rules.txt
@@ -91,28 +91,28 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x900 (16:10)
 $width = 1440
 $height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1044 (16:10)
 $width = 1680
 $height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
 $height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1584 (16:10)
 $width = 2560
 $height = 1584 // 720x2.2
 $gameWidth = 1280
@@ -133,7 +133,7 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3168 (16:10)
+name = 5120x3204 (16:10)
 $width = 5120
 $height = 3204 // 720x4.45
 $gameWidth = 1280

--- a/Source/SuperMario3DWorld_Resolution/rules.txt
+++ b/Source/SuperMario3DWorld_Resolution/rules.txt
@@ -91,51 +91,51 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x900 (16:10)
+name = 1440x936 (16:10)
 $width = 1440
-$height = 900
+$height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1050 (16:10)
+name = 1680x1080 (16:10)
 $width = 1680
-$height = 1050
+$height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1200 (16:10)
+name = 1920x1224 (16:10)
 $width = 1920
-$height = 1200
+$height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1600 (16:10)
+name = 2560x1656 (16:10)
 $width = 2560
-$height = 1600
+$height = 1584 // 720x2.2
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 2880x1800 (16:10)
 $width = 2880
-$height = 1800
+$height = 1800 // 720x2.5
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2400 (16:10)
+name = 3840x2412 (16:10)
 $width = 3840
-$height = 2400
+$height = 2412 // 720x3.35
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3200 (16:10)
+name = 5120x3168 (16:10)
 $width = 5120
-$height = 3200
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 

--- a/Source/TokyoMirage_Resolution/rules.txt
+++ b/Source/TokyoMirage_Resolution/rules.txt
@@ -5,8 +5,6 @@ path = "Tokyo Mirage Sessions FE/Graphics/Resolution"
 description = Changes the resolution of the game.
 version = 3
 
-// Performance
-
 [Preset]
 name = 1280x720 (Default)
 $width = 1280
@@ -90,61 +88,54 @@ $height = 1440
 $gameWidth = 1280
 $gameHeight = 720
 
-[Preset]
-name = 3840x1600 ("21:9")
-$width = 3840
-$height = 1600
-$gameWidth = 1280
-$gameHeight = 720
-
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x900 (16:10)
+name = 1440x936 (16:10)
 $width = 1440
-$height = 900
+$height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1050 (16:10)
+name = 1680x1080 (16:10)
 $width = 1680
-$height = 1050
+$height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1200 (16:10)
+name = 1920x1224 (16:10)
 $width = 1920
-$height = 1200
+$height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1600 (16:10)
+name = 2560x1656 (16:10)
 $width = 2560
-$height = 1600
+$height = 1584 // 720x2.2
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 2880x1800 (16:10)
 $width = 2880
-$height = 1800
+$height = 1800 // 720x2.5
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2400 (16:10)
+name = 3840x2412 (16:10)
 $width = 3840
-$height = 2400
+$height = 2412 // 720x3.35
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3200 (16:10)
+name = 5120x3168 (16:10)
 $width = 5120
-$height = 3200
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 

--- a/Source/TokyoMirage_Resolution/rules.txt
+++ b/Source/TokyoMirage_Resolution/rules.txt
@@ -91,28 +91,28 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x900 (16:10)
 $width = 1440
 $height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1044 (16:10)
 $width = 1680
 $height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
 $height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1584 (16:10)
 $width = 2560
 $height = 1584 // 720x2.2
 $gameWidth = 1280
@@ -133,7 +133,7 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3168 (16:10)
+name = 5120x3204 (16:10)
 $width = 5120
 $height = 3204 // 720x4.45
 $gameWidth = 1280

--- a/Source/TropicalFreeze_Resolution/rules.txt
+++ b/Source/TropicalFreeze_Resolution/rules.txt
@@ -89,30 +89,29 @@ $gameWidth = 1280
 $gameHeight = 720
 
 // Common 16:10 Resolutions
-
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x900 (16:10)
 $width = 1440
 $height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1044 (16:10)
 $width = 1680
 $height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
 $height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1584 (16:10)
 $width = 2560
 $height = 1584 // 720x2.2
 $gameWidth = 1280
@@ -133,7 +132,7 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3168 (16:10)
+name = 5120x3204 (16:10)
 $width = 5120
 $height = 3204 // 720x4.45
 $gameWidth = 1280

--- a/Source/TropicalFreeze_Resolution/rules.txt
+++ b/Source/TropicalFreeze_Resolution/rules.txt
@@ -91,51 +91,51 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x900 (16:10)
+name = 1440x936 (16:10)
 $width = 1440
-$height = 900
+$height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1050 (16:10)
+name = 1680x1080 (16:10)
 $width = 1680
-$height = 1050
+$height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1200 (16:10)
+name = 1920x1224 (16:10)
 $width = 1920
-$height = 1200
+$height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1600 (16:10)
+name = 2560x1656 (16:10)
 $width = 2560
-$height = 1600
+$height = 1584 // 720x2.2
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 2880x1800 (16:10)
 $width = 2880
-$height = 1800
+$height = 1800 // 720x2.5
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2400 (16:10)
+name = 3840x2412 (16:10)
 $width = 3840
-$height = 2400
+$height = 2412 // 720x3.35
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3200 (16:10)
+name = 5120x3168 (16:10)
 $width = 5120
-$height = 3200
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 

--- a/docs/resources/resolutions_1080.md
+++ b/docs/resources/resolutions_1080.md
@@ -87,51 +87,51 @@ $gameHeight = 1080
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x918 (16:10)
 $width = 1440
-$height = 936 // 720x1.3
-$gameWidth = 1280
-$gameHeight = 720
+$height = 918 // 1080x0.85
+$gameWidth = 1920
+$gameHeight = 1080
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1026 (16:10)
 $width = 1680
-$height = 1080 // 720x1.5
-$gameWidth = 1280
-$gameHeight = 720
+$height = 1026 // 1080x0.95
+$gameWidth = 1920
+$gameHeight = 1080
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
-$height = 1224 // 720x1.7
-$gameWidth = 1280
-$gameHeight = 720
+$height = 1188 // 1080x1.1
+$gameWidth = 1920
+$gameHeight = 1080
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1620 (16:10)
 $width = 2560
-$height = 1656 // 720x2.3
-$gameWidth = 1280
-$gameHeight = 720
+$height = 1620 // 1080x1.5
+$gameWidth = 1920
+$gameHeight = 1080
 
 [Preset]
-name = 2880x1800 (16:10)
+name = 2880x1782 (16:10)
 $width = 2880
-$height = 1800 // 720x2.5
-$gameWidth = 1280
-$gameHeight = 720
+$height = 1782 // 1080x1.65
+$gameWidth = 1920
+$gameHeight = 1080
 
 [Preset]
-name = 3840x2448 (16:10)
+name = 3840x2376 (16:10)
 $width = 3840
-$height = 2448 // 720x3.4
-$gameWidth = 1280
-$gameHeight = 720
+$height = 2376 // 1080x2.2
+$gameWidth = 1920
+$gameHeight = 1080
 
 [Preset]
-name = 5120x3168 (16:10)
+name = 5120x3186 (16:10)
 $width = 5120
-$height = 3168 // 720x4.4
-$gameWidth = 1280
-$gameHeight = 720
+$height = 3186 // 1080x2.95
+$gameWidth = 1920
+$gameHeight = 1080
 ```

--- a/docs/resources/resolutions_720.md
+++ b/docs/resources/resolutions_720.md
@@ -87,28 +87,28 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x936 (16:10)
+name = 1440x900 (16:10)
 $width = 1440
 $height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1080 (16:10)
+name = 1680x1044 (16:10)
 $width = 1680
 $height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1224 (16:10)
+name = 1920x1188 (16:10)
 $width = 1920
 $height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1656 (16:10)
+name = 2560x1584 (16:10)
 $width = 2560
 $height = 1584 // 720x2.2
 $gameWidth = 1280
@@ -129,7 +129,7 @@ $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3168 (16:10)
+name = 5120x3204 (16:10)
 $width = 5120
 $height = 3204 // 720x4.45
 $gameWidth = 1280

--- a/docs/resources/resolutions_720.md
+++ b/docs/resources/resolutions_720.md
@@ -87,51 +87,51 @@ $gameHeight = 720
 // Common 16:10 Resolutions
 
 [Preset]
-name = 1440x900 (16:10)
+name = 1440x936 (16:10)
 $width = 1440
-$height = 900
+$height = 900 // 720x1.25
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1680x1050 (16:10)
+name = 1680x1080 (16:10)
 $width = 1680
-$height = 1050
+$height = 1044 // 720x1.45
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 1920x1200 (16:10)
+name = 1920x1224 (16:10)
 $width = 1920
-$height = 1200
+$height = 1188 // 720x1.65
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 2560x1600 (16:10)
+name = 2560x1656 (16:10)
 $width = 2560
-$height = 1600
+$height = 1584 // 720x2.2
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
 name = 2880x1800 (16:10)
 $width = 2880
-$height = 1800
+$height = 1800 // 720x2.5
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 3840x2400 (16:10)
+name = 3840x2412 (16:10)
 $width = 3840
-$height = 2400
+$height = 2412 // 720x3.35
 $gameWidth = 1280
 $gameHeight = 720
 
 [Preset]
-name = 5120x3200 (16:10)
+name = 5120x3168 (16:10)
 $width = 5120
-$height = 3200
+$height = 3204 // 720x4.45
 $gameWidth = 1280
 $gameHeight = 720
 ```


### PR DESCRIPTION
can I use 2 decimal places instead of 1 for multiplier, see commit changes.

Also, why is $gameWidth and $gameHeight for resolutions_1080.md 1280 and 720 respectively?

Finally, removed 4300x1800 in botw rules.txt (consistency)