### PR TITLE
Added workaround pack for eShop

### DIFF
--- a/Workarounds/eShop_RemoveGrayOverlay/fcd26205b94e11ca_000000000000001f_ps.txt
+++ b/Workarounds/eShop_RemoveGrayOverlay/fcd26205b94e11ca_000000000000001f_ps.txt
@@ -1,0 +1,57 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_separate_shader_objects : enable
+uniform ivec4 uf_remappedPS[2];
+uniform float uf_alphaTestRef;
+layout(binding = 0) uniform sampler2D textureUnitPS0;
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
+layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = passParameterSem0;
+R1f = passParameterSem1;
+R1f.xyzw = (texture(textureUnitPS0, R1f.xy).xyzw); // TEX_INST_SAMPLE OffsetXYZ 00 00 00
+discard;
+// 0
+R127f.z = (mul_nonIEEE(R1f.y,intBitsToFloat(uf_remappedPS[0].y)) + intBitsToFloat(uf_remappedPS[1].y));
+R123f.w = (mul_nonIEEE(R1f.x,intBitsToFloat(uf_remappedPS[0].x)) + intBitsToFloat(uf_remappedPS[1].x));
+PV0f.w = R123f.w;
+// 1
+R123f.x = (mul_nonIEEE(R1f.w,intBitsToFloat(uf_remappedPS[0].w)) + intBitsToFloat(uf_remappedPS[1].w));
+PV1f.x = R123f.x;
+R123f.y = (mul_nonIEEE(R1f.z,intBitsToFloat(uf_remappedPS[0].z)) + intBitsToFloat(uf_remappedPS[1].z));
+PV1f.y = R123f.y;
+R1f.x = mul_nonIEEE(R0f.x, PV0f.w);
+PS1f = R1f.x;
+// 2
+R1f.y = mul_nonIEEE(R0f.y, R127f.z);
+R1f.z = mul_nonIEEE(R0f.z, PV1f.y);
+R1f.w = mul_nonIEEE(R0f.w, PV1f.x);
+// export
+passPixelColor0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+}

--- a/Workarounds/eShop_RemoveGrayOverlay/fcd26205b94e11ca_0000000000000079_ps.txt
+++ b/Workarounds/eShop_RemoveGrayOverlay/fcd26205b94e11ca_0000000000000079_ps.txt
@@ -1,0 +1,56 @@
+#version 420
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_separate_shader_objects : enable
+uniform ivec4 uf_remappedPS[2];
+layout(binding = 0) uniform sampler2D textureUnitPS0;
+layout(location = 0) in vec4 passParameterSem0;
+layout(location = 1) in vec4 passParameterSem1;
+layout(location = 0) out vec4 passPixelColor0;
+uniform vec2 uf_fragCoordScale;
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R123f = vec4(0.0);
+vec4 R127f = vec4(0.0);
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = passParameterSem0;
+R1f = passParameterSem1;
+R1f.xyzw = (texture(textureUnitPS0, R1f.xy).xyzw); // TEX_INST_SAMPLE OffsetXYZ 00 00 00
+discard;
+// 0
+R127f.z = (mul_nonIEEE(R1f.y,intBitsToFloat(uf_remappedPS[0].y)) + intBitsToFloat(uf_remappedPS[1].y));
+R123f.w = (mul_nonIEEE(R1f.x,intBitsToFloat(uf_remappedPS[0].x)) + intBitsToFloat(uf_remappedPS[1].x));
+PV0f.w = R123f.w;
+// 1
+R123f.x = (mul_nonIEEE(R1f.w,intBitsToFloat(uf_remappedPS[0].w)) + intBitsToFloat(uf_remappedPS[1].w));
+PV1f.x = R123f.x;
+R123f.y = (mul_nonIEEE(R1f.z,intBitsToFloat(uf_remappedPS[0].z)) + intBitsToFloat(uf_remappedPS[1].z));
+PV1f.y = R123f.y;
+R1f.x = mul_nonIEEE(R0f.x, PV0f.w);
+PS1f = R1f.x;
+// 2
+R1f.y = mul_nonIEEE(R0f.y, R127f.z);
+R1f.z = mul_nonIEEE(R0f.z, PV1f.y);
+R1f.w = mul_nonIEEE(R0f.w, PV1f.x);
+// export
+passPixelColor0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+}

--- a/Workarounds/eShop_RemoveGrayOverlay/rules.txt
+++ b/Workarounds/eShop_RemoveGrayOverlay/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 000500301001400a,000500301001410a,000500301001420a
+name = "Remove gray overlay"
+version = 3
+path = "Nintendo eShop/Workarounds/Remove gray overlay"
+description = Hides the gray overlay covering the lower half of the screen


### PR DESCRIPTION
For some reason eShop renders a gray square/overlay over the lower half of the TV output.
Screenshot of the problem:
![eshop_bug](https://user-images.githubusercontent.com/13877693/49305529-cbd5e380-f4cf-11e8-967f-03f735eaed48.jpg)

The pack modifies the overlay render shader to discard all pixels. Doesn't seem to have any negative side effects