### PR TITLE
Included missing titleId

### DIFF
--- a/Resolutions/MarioKart8_Resolution/rules.txt
+++ b/Resolutions/MarioKart8_Resolution/rules.txt
@@ -1,5 +1,5 @@
 [Definition]
-titleIds = 000500001010ec00,000500001010ed00,000500001010eb00
+titleIds = 000500001010ec00,000500001010ed00,000500001010eb00,00050000ffffffff
 name = Resolution
 path = "Mario Kart 8/Graphics/Resolution"
 description = Changes the resolution of the game.


### PR DESCRIPTION
Mario Kart 8 is listed as 00050000-ffffffff in Cemu on my PC, so I have to type in 00050000ffffffff in the Graphic Pack to make Cemu apply higher res in Mario Kart 8 on my system.