### PR TITLE
[BotW] 38" ultrawide resolution (3840x1600) added

### DIFF
--- a/Resolutions/BreathOfTheWild_Resolution/rules.txt
+++ b/Resolutions/BreathOfTheWild_Resolution/rules.txt
@@ -124,6 +124,14 @@ $gameHeight = 720
 $heightfix = 0
 
 [Preset]
+name = 3840x1600 (21:10)
+$width = 3840
+$height = 1600
+$gameWidth = 1280
+$gameHeight = 720
+$heightfix = 0
+
+[Preset]
 name = 4300x1800 (21:9)
 $width = 4300
 $height = 1800


### PR DESCRIPTION
i've added the resolution 3840x1600 (21:10) for BotW.
i own a LG 38WK95C-W which runs at 3840x1600 and its resolution was missing.