### PR TITLE
[BotW] Circular blur: cut costs with linear

### DIFF
--- a/Resolutions/BreathOfTheWild_Resolution/cb0e6e8cbec4502a_0000000000000079_ps.txt
+++ b/Resolutions/BreathOfTheWild_Resolution/cb0e6e8cbec4502a_0000000000000079_ps.txt
@@ -1,29 +1,29 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_arrays_of_arrays : enable
-// shader cb0e6e8cbec4502a 
-// Used for: Horizontal+Vertical Battle, Camera and Scope Depth of Field Blur
+#extension GL_ARB_separate_shader_objects : enable
 
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf5c7b800 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
+// shader cb0e6e8cbec4502a 
+// Used for: 1 pass Battle, Camera and Scope Depth of Field Blur
+
+layout(binding = 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem3;
 layout(location = 0) out vec4 passPixelColor0;
 uniform vec2 uf_fragCoordScale;
 
-const float resScale = $height/720;
-const int radius = int(2*resScale);
+int radius = int( roundEven(2.0/uf_fragCoordScale.y) );
+vec2 resolution = vec2( textureSize(textureUnitPS0,0) );
 
 void main() {
-	vec2 center = (passParameterSem3.xy + passParameterSem3.zw) / 2;
-	vec2 step = passParameterSem3.xw - passParameterSem3.zy;
-	vec4 result = vec4(0.0);
+	vec2 center = ( passParameterSem3.xy + passParameterSem3.zw ) / 2.0 ;
+	vec3 result = vec3(0.0);
 	float count = 0.0;
-	for (int x = -radius; x <= radius; x++) {
-		for (int y = -radius; y <= radius; y++) {
-			if (length(vec2(x, y)) <= radius) {
-				result += texture(textureUnitPS0, center + vec2(x, y)*step);
+	for ( int x = 1-radius; x <= radius-1; x+=2 ) {
+		for ( int y = 1-radius; y <= radius-1; y+=2 ) {
+			if ( length(vec2(x, y)) <= radius ) {
+				result += texture( textureUnitPS0, center + vec2(x, y)/resolution ).xyz ;
 				count += 1.0;
 			}
 		}
 	}
-	passPixelColor0 = result / count;
+	passPixelColor0 = vec4( result / count, 0.0 );
 }


### PR DESCRIPTION
By sampling at the 2x2 center of 4 adjacent texels, we get the average of the squad at once. Reducing 64 samples to 16 at 1440p.
I believe this is what the game was doing as well:
1. the result texture is set to half the original res.
2. the shift in coordinates is 1 seen in the vertex shader.

It means that instead of sampling at the texel center of textureUnitPS0, it samples at the 4 corner of the 2x2 square. For GPU's linear interpolation, each sampling gives the average value of 4 neighboring texels, together it gets all 16 texels in the 4x4 square... with just 4 fetches.

We can mimic this in our circular blur shader. The result at 1440p is slightly less blurry than native 720p when using sheikah scope. But I don't think it's completely because of this shader, as the sheikah scope uses this in combine with a fixed radius blur shader, so less blur is expected.