### PR TITLE
[BotW] Fix 960x540 background ambient light, bloom

### DIFF
--- a/Resolutions/BreathOfTheWild_Resolution/rules.txt
+++ b/Resolutions/BreathOfTheWild_Resolution/rules.txt
@@ -312,7 +312,7 @@ $heightfix = 0
 width = 1280
 height = 720
 formats = 0x001,0x005,0x007,0x019,0x01a,0x41a,0x80e,0x806,0x816,0x820
-formatsExcluded = 0x008 # Game Load Opening Background Image
+# formatsExcluded = 0x008 # Game Load Opening Background Image
 tileModesExcluded = 0x001 # For Video Playback
 overwriteWidth = ($width/$gameWidth)* 1280
 overwriteHeight = ($height/$gameHeight)* 720
@@ -322,7 +322,7 @@ overwriteHeight = ($height/$gameHeight)* 720
 width = 864
 height = 480
 formats = 0x019
-formatsExcluded = 0x034 # Exclude 0x034 which is used for large album thumbnails
+# formatsExcluded = 0x034 # Exclude 0x034 which is used for large album thumbnails
 overwriteWidth = ($width/$gameWidth)* 864
 overwriteHeight = ($height/$gameHeight)* 480
 
@@ -331,7 +331,7 @@ overwriteHeight = ($height/$gameHeight)* 480
 width = 854
 height = 480
 formats = 0x019
-formatsExcluded = 0x034 # Exclude 0x034 which is used for large album thumbnails
+# formatsExcluded = 0x034 # Exclude 0x034 which is used for large album thumbnails
 overwriteWidth = ($width/$gameWidth)* 854
 overwriteHeight = ($height/$gameHeight)* 480
 
@@ -350,7 +350,7 @@ overwriteHeight = ($height/$gameHeight)* 480
 width = 640
 height = 368
 formats = 0x001,0x005,0x007,0x019,0x01a,0x80e,0x806,0x816,0x820,0x41a
-formatsExcluded = 0x431 # Exclude 0x431 which is used for adventure log images
+# formatsExcluded = 0x431 # Exclude 0x431 which is used for adventure log images
 overwriteWidth = ($width/$gameWidth) * 640
 overwriteHeight = (($height/$gameHeight) * 368) + $heightfix
 
@@ -359,7 +359,7 @@ overwriteHeight = (($height/$gameHeight) * 368) + $heightfix
 width = 640
 height = 360
 formats = 0x001,0x005,0x007,0x019,0x01a,0x80e,0x806,0x816,0x820,0x41a
-formatsExcluded = 0x431
+# formatsExcluded = 0x431
 tileModesExcluded = 0x001 # For Video Playback
 overwriteWidth = ($width/$gameWidth) * 640
 overwriteHeight = ($height/$gameHeight) * 360
@@ -412,21 +412,21 @@ formats = 0x001,0x005,0x007,0x806,0x80e,0x816
 overwriteWidth = ($width/$gameWidth) * 160
 overwriteHeight = ($height/$gameHeight) * 90
 
-# Required 1/10 resolution
-[TextureRedefine]
-width = 128
-height = 80
-formats = 0x005,0x007,0x019,0x01a,0x80e,0x816,0x806,0x820,0x41a
-overwriteWidth = ($width/$gameWidth) * 128
-overwriteHeight = ($height/$gameHeight) * 80
-
-# Required 1/10 resolution
-[TextureRedefine]
-width = 120
-height = 75
-formats = 0x005,0x007,0x019,0x01a,0x80e,0x816,0x806,0x820,0x41a
-overwriteWidth = ($width/$gameWidth) * 120
-overwriteHeight = ($height/$gameHeight) * 75
+# 1/10 resolution; Break 960x540 background: ambient light, bloom
+# 
+# [TextureRedefine]
+# width = 128
+# height = 80
+# formats = 0x005,0x007,0x019,0x01a,0x80e,0x816,0x806,0x820,0x41a
+# overwriteWidth = ($width/$gameWidth) * 128
+# overwriteHeight = ($height/$gameHeight) * 80
+# 
+# [TextureRedefine]
+# width = 120
+# height = 75
+# formats = 0x005,0x007,0x019,0x01a,0x80e,0x816,0x806,0x820,0x41a
+# overwriteWidth = ($width/$gameWidth) * 120
+# overwriteHeight = ($height/$gameHeight) * 75
 
 # Required Fogs and Dust
 [TextureRedefine]
@@ -522,7 +522,7 @@ tilemodes = 4
 overwriteWidth = ($width/$gameWidth) * 64
 overwriteHeight = ($height/$gameHeight) * 32
 
-[TextureRedefine]
+[TextureRedefine] # catches cubemap! 32x32, 16x16
 width = 32
 height = 16
 depth = 1
@@ -717,3 +717,69 @@ formats = 0x019
 overwriteFormat = 0x01f
 overwriteWidth = ($width/$gameWidth) * 110
 overwriteHeight = ($height/$gameHeight) * 720
+
+# Fix texture cache's mismatch warnings
+
+[TextureRedefine] # 1280x720; Map: travel confirm menu background blur
+width = 1280
+height = 288
+depth = 1
+formats = 0x19
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 1280
+overwriteHeight = ($height/$gameHeight) * 288
+
+[TextureRedefine] # same as above
+width = 1280
+height = 278
+depth = 1
+formats = 0x19
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 1280
+overwriteHeight = ($height/$gameHeight) * 278
+
+[TextureRedefine] # 640x360 mip 1; Scope dof close-up depth
+width = 512
+height = 256
+depth = 1
+formats = 0x1
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 512
+overwriteHeight = ($height/$gameHeight) * 256
+
+[TextureRedefine] # 640x360 mip 2; same as above
+width = 256
+height = 128
+depth = 1
+formats = 0x1
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 256
+overwriteHeight = ($height/$gameHeight) * 128
+
+# Uncomment if HUD setting is Pro
+# [TextureRedefine] # 640x360 mip 3; Designated level for dof processing. breaks sound wave HUD
+# width = 128
+# height = 64
+# depth = 1
+# formats = 0x1
+# tilemodes = 4
+# overwriteWidth = ($width/$gameWidth) * 128
+# overwriteHeight = ($height/$gameHeight) * 64
+
+[TextureRedefine] # 320x180; Blur on center piece of the map. not used at the moment of the capture
+width = 293
+height = 185
+depth = 1
+formats = 0x1a
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 293
+overwriteHeight = ($height/$gameHeight) * 185
+
+# [TextureRedefine] # 128x64; Fix sound HUD, breaks icons and teleport strips
+# width = 64
+# height = 64
+# depth = 1
+# formats = 0x1
+# tilemodes = 4
+# overwriteWidth = ($width/$gameWidth) * 64
+# overwriteHeight = ($height/$gameHeight) * 64


### PR DESCRIPTION
...And other texture cache's mismatch warnings.

Uncomment 128x64 for a scope DOF fix at line 760 if HUD setting is Pro, since the game doesn't draw the sound HUD.

Resizing 0x1,0x1a has the risk of breaking textures, tho there wasn't any game texture matching the resolution and format in Nsight resource tab. I haven't notice any obvious breaking while playing.
Separate slices of Cubemap being caught by 32x16 resize is not fixed. It needs too many 0x816, 0x1a resizes to not have texture mismatches.
Also I changed to file to Windows(CR LF), thus the diff...

What was 1/10 resolution intended for?

1/10 resized, missing bloom and ambient lighting('red filter').
![old](https://user-images.githubusercontent.com/21133512/61876154-c48a9c80-aedb-11e9-9fe3-d4566f76b153.png)
native, the fixed version looks the same.
![native](https://user-images.githubusercontent.com/21133512/61876181-d409e580-aedb-11e9-89b7-0980381e1639.png)

I have no idea what the game is doing with this, it's prepared with blurs but not getting used at the time of the captures. Still, I've added the rule to avoid breaking it.
![1](https://user-images.githubusercontent.com/21133512/61876265-fef43980-aedb-11e9-926b-0de835f3cc41.PNG)
