### PR TITLE
[BotW] Resize letters box to make text less blurry

### DIFF
--- a/Mods/BreathOfTheWild_ChangeAncientGlowColor/Readme.txt
+++ b/Mods/BreathOfTheWild_ChangeAncientGlowColor/Readme.txt
@@ -8,4 +8,4 @@
 # Game control color & brightness with a uniform, so they can vary between objects (and through time) drawn with the same shader. It's hard to do this in Gfx pack.
 # In theory You can add if condition to check for game's uniform value so you can change the color of a specific object without affecting others.
 
-# Try converting custom color from gamma encoded to linear (color/255^2.2) if it look slightly off in game.
+# Try converting custom color from gamma encoded to linear (color/255)^2.2 if it look slightly off in game.

--- a/Mods/BreathOfTheWild_ChangeAncientGlowColor/Readme.txt
+++ b/Mods/BreathOfTheWild_ChangeAncientGlowColor/Readme.txt
@@ -8,4 +8,4 @@
 # Game control color & brightness with a uniform, so they can vary between objects (and through time) drawn with the same shader. It's hard to do this in Gfx pack.
 # In theory You can add if condition to check for game's uniform value so you can change the color of a specific object without affecting others.
 
-# Try converting custom color from gamma encoded to linear (color^0.45) if it look slightly off in game.
+# Try converting custom color from gamma encoded to linear (color/255^2.2) if it look slightly off in game.

--- a/Resolutions/BreathOfTheWild_Resolution/rules.txt
+++ b/Resolutions/BreathOfTheWild_Resolution/rules.txt
@@ -295,6 +295,7 @@ $gameWidth = 1280
 $gameHeight = 720
 $heightfix = 0
 
+
 # All 720p textures:
 # - 0x001=World Lighting Red8
 # - 0x005=Link and Objects Depth
@@ -783,3 +784,43 @@ overwriteHeight = ($height/$gameHeight) * 185
 # tilemodes = 4
 # overwriteWidth = ($width/$gameWidth) * 64
 # overwriteHeight = ($height/$gameHeight) * 64
+
+# Resize letters box: Subtitle
+
+[TextureRedefine]
+width = 512
+height = 96
+depth = 1
+formats = 0x1a
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 512
+overwriteHeight = ($height/$gameHeight) * 96
+
+[TextureRedefine]
+width = 500
+height = 94
+depth = 1
+formats = 0x1a
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 500
+overwriteHeight = ($height/$gameHeight) * 94
+
+# Resize letters box: pop up message
+
+[TextureRedefine]
+width = 480
+height = 32
+depth = 1
+formats = 0x1a
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 480
+overwriteHeight = ($height/$gameHeight) * 32
+
+[TextureRedefine]
+width = 464
+height = 28
+depth = 1
+formats = 0x1a
+tilemodes = 4
+overwriteWidth = ($width/$gameWidth) * 464
+overwriteHeight = ($height/$gameHeight) * 28


### PR DESCRIPTION
For many cutscenes the game draw the subtitles on a 500x94 box first and apply the box with the letters onto the screen. Resized the box to make subtitles less blurry.
Text bloom/effect use another 560x150 box, it's good not having to resize it.
![orig](https://user-images.githubusercontent.com/21133512/62001530-41f51d80-b125-11e9-8bf4-113985ec54b2.png)
![up](https://user-images.githubusercontent.com/21133512/62001532-46213b00-b125-11e9-979a-6f7cdd402a1a.png)
The pop up message is also sharper after resizing, but looks like it might have been over-sampled a bit.
![orig2](https://user-images.githubusercontent.com/21133512/62001534-49b4c200-b125-11e9-9238-65da320a303c.png)
![up2](https://user-images.githubusercontent.com/21133512/62001535-4ae5ef00-b125-11e9-9923-01f66849e786.png)
