### PR TITLE
[Wind Waker HD] Added Picto-Box workaround

### DIFF
--- a/Workarounds/WindWakerHD_PictoBox/patches.txt
+++ b/Workarounds/WindWakerHD_PictoBox/patches.txt
@@ -1,0 +1,33 @@
+[WW_USA]
+moduleMatches = 0x475BD29F
+
+_sub_exit = 0x022D0138
+
+#First picture
+0x022D00E8 = nop           ; cmp r0, 1
+0x022D00EC = b _sub_exit   ; beq 0x022D0138
+
+#Second picture
+0x022D0114 = nop           ; cmp r0, 2
+0x022D0118 = nop           ; bne 0x022D00F0
+
+#Third picture
+0x022D0130 = nop           ; cmp r0, 3
+0x022D0134 = nop           ; bne 0x022D00F0
+
+[WW_EUR]
+moduleMatches = 0xB7E748DE
+
+_sub_exit = 0x022D013C
+
+#First picture
+0x022D00EC = nop           ; cmp r0, 1
+0x022D00F0 = b _sub_exit   ; beq 0x022D013C
+
+#Second picture
+0x022D0118 = nop           ; cmp r0, 2
+0x022D011C = nop           ; bne 0x022D00F4
+
+#Third picture
+0x022D0134 = nop           ; cmp r0, 3
+0x022D0138 = nop           ; bne 0x022D00F4

--- a/Workarounds/WindWakerHD_PictoBox/readme.txt
+++ b/Workarounds/WindWakerHD_PictoBox/readme.txt
@@ -1,0 +1,1 @@
+For loadline versions, try looking up addresses from patches.txt in PPC debugger. Correct opcodes should be near these addresses. Changing it should be easy.

--- a/Workarounds/WindWakerHD_PictoBox/rules.txt
+++ b/Workarounds/WindWakerHD_PictoBox/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010143500,0005000010143600
+name = Picto-Box Fix
+path = "The Legend of Zelda: The Wind Waker HD/Workarounds/Picto-Box Fix"
+description = This is more of a cheat than workaround. Forces Lenzo to accept any pictures in the quest 'Lenzo's Research Assistant'.
+version = 3


### PR DESCRIPTION
Added workaround for 'Lenzo's Research Assistant' quest. Lezlo will now accept any picture shown. Works with USA and EUR versions.