### PR TITLE
Updated some gfx packs to v4

### DIFF
--- a/Enhancements/BreathOfTheWild_Clarity/37040a485a29d54e_00000000000003c9_ps.txt
+++ b/Enhancements/BreathOfTheWild_Clarity/37040a485a29d54e_00000000000003c9_ps.txt
@@ -923,12 +923,41 @@ float DPX_Strength = 0.20;
 
 //###########################################################
 
-uniform ivec4 uf_remappedPS[1];
-layout(binding = 0) uniform sampler2D textureUnitPS0; // Bloom 
-layout(binding = 1) uniform sampler2D textureUnitPS1;// HDR LumaShapening.
+// Start of shader inputs/outputs, predetermined by Cemu. Do not touch
+
+#ifdef VULKAN
+   #define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+   #define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+   #define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#else
+   #define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+   #define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+   #define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+
+// uniform vars
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
+   uniform ivec4 uf_remappedPS[1];
+   uniform vec4 uf_fragCoordScale;
+};
+#else
+   uniform ivec4 uf_remappedPS[1];
+   uniform vec2 uf_fragCoordScale;
+#endif
+
+// textures
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0; // Bloom 
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1; // HDR LumaShapening
+
+// pixel shader inputs
 layout(location = 0) in vec4 passParameterSem0;
+
+// color outputs
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+
+// End of shader inputs/outputs
 
 //ToneMapping
 

--- a/Enhancements/BreathOfTheWild_Clarity/rules.txt
+++ b/Enhancements/BreathOfTheWild_Clarity/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = "Clarity (NOT COMPATIBLE WITH MONOCHROMIA)"
 path = "The Legend of Zelda: Breath of the Wild/Enhancements/Clarity"
 description = NOT COMPATIBLE WITH MONOCHROMIA! Select the visual look of the game that you'll like with these hand-made presets that adjusts saturation, vibrance, colors and more. You can select a preset. Selecting "User-Defined" requires making your own preset. check the "BreathOfTheWild_Clarity/37040a485a29d54e_00000000000003c9_ps.txt" file in your graphicPacks folder to create one.
-version = 3
+version = 4
 
 [Preset]
 name = Serfrost Preset (Default)

--- a/Enhancements/BreathOfTheWild_LODBias/rules.txt
+++ b/Enhancements/BreathOfTheWild_LODBias/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = "Level Of Detail Bias"
 path = "The Legend of Zelda: Breath of the Wild/Enhancements/LOD Bias"
 description = Setting your Level Of Detail bias changes the detail level of the textures that are used. Using a preset with a negative value will use higher resolution textures whereas choosing a preset with a positive value decreases the resolution of the textures that are used.
-version = 3
+version = 4
 
 [Preset]
 name = Normal texture detail (Default)

--- a/Mods/BreathOfTheWild_Cheats_FasterArrowDraw/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_FasterArrowDraw/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Faster Arrow Draw
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Faster Arrow Draw"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfArrows/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfArrows/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Arrows
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Arrows"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfDaruk/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfDaruk/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Daruk's Protection
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Daruk's Protection"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfHearts/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfHearts/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Hearts
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Hearts"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfMipha/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfMipha/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Mipha's Grace
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Mipha's Grace"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfMotorcycle/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfMotorcycle/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Motorcycle Energy
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Motorcycle Energy"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfRevali/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfRevali/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Revali's Gale
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Revali's Gale"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfStamina/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfStamina/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Stamina
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Stamina"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfUrbosa/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfUrbosa/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Urbosa's Fury
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Urbosa's Fury"
 description = BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_InfWeapons/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_InfWeapons/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Infinite Weapons, Bows and Shields
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Infinite Weapons, Bows and Shields"
 description = (except burn damage and throwing weapon) BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_Cheats_MotorcycleAnywhere/rules.txt
+++ b/Mods/BreathOfTheWild_Cheats_MotorcycleAnywhere/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Spawn Motorcycle Anywhere
 path = "The Legend of Zelda: Breath of the Wild/Mods/Cheats/Spawn Motorcycle Anywhere"
 description = v208 only! Credits to Zeikken (converting to patches) and leoetlino (finding the value). BotW Cheats by C313571N and Xalphenos
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_DayLength/rules.txt
+++ b/Mods/BreathOfTheWild_DayLength/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Day Length
 path = "The Legend of Zelda: Breath of the Wild/Mods/Day Length"
 description = Changes the amount of real time an in-game day takes. Any game slowdown will make the actual time longer. Blood moons won't appear or be less common.
-version = 3
+version = 4
 
 [Preset]
 name = 48 minutes

--- a/Mods/BreathOfTheWild_FPS++/Dynamic Gamespeed/rules.txt
+++ b/Mods/BreathOfTheWild_FPS++/Dynamic Gamespeed/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Dynamic Gamespeed
 path = "The Legend of Zelda: Breath of the Wild/Mods/FPS++/Dynamic Gamespeed (Required)"
 description = DON'T USE STATIC FPS WITH FPS++! Don't forget to set the FPS limit if you want to exceed 30 FPS. Lowering the amount of averaged frames, how more reactive the gamespeed becomes to your FPS.
-version = 3
+version = 4
 
 [Preset]
 name = 32 Frames Averaged

--- a/Mods/BreathOfTheWild_FPS++/Fence Method/rules.txt
+++ b/Mods/BreathOfTheWild_FPS++/Fence Method/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Fence Method
 path = "The Legend of Zelda: Breath of the Wild/Mods/FPS++/Fence Method (Required)"
 description = Performance fence gives better performance with some CPU's and some (lower) resolutions. Accurate fence likely solves all of the milk water. Fence skip will likely cause milk water.
-version = 3
+version = 4
 
 [Preset]
 name = Performance Fence

--- a/Mods/BreathOfTheWild_FPS++/Limit FPS/rules.txt
+++ b/Mods/BreathOfTheWild_FPS++/Limit FPS/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Set FPS Limit
 path = "The Legend of Zelda: Breath of the Wild/Mods/FPS++/Set FPS Limit (Required)"
 description = Sets a cap on the FPS. If you want no gameplay bugs, use 30FPS. These bugs range from crashing after cutscenes, certain boss fights will fly away to the horizon and some physics are more intense.
-version = 3
+version = 4
 
 [Preset]
 name = 60FPS (ideal for 240/120/60Hz displays)

--- a/Mods/BreathOfTheWild_FPS++/Occlusion Query/rules.txt
+++ b/Mods/BreathOfTheWild_FPS++/Occlusion Query/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = CPU Occlusion Query
 path = "The Legend of Zelda: Breath of the Wild/Mods/FPS++/NPC Stutter Fix (CPU Occlusion Query)"
 description = Changes occlusion queries from GPU to CPU type. This is a workaround for the NPC or creatures stuttering at a distance when full sync at GX2DrawDone is disabled. If you disable that option for extra FPS, you will need to enable the LWZX workaround to fix (most) crashes if you disable this.
-version = 3
+version = 4

--- a/Mods/BreathOfTheWild_NoMMTriforce/rules.txt
+++ b/Mods/BreathOfTheWild_NoMMTriforce/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = No Master Mode Triforce
 path = "The Legend of Zelda: Breath of the Wild/Mods/No Master Mode Triforce"
 description = Removes the on-screen triforce icon in Master Mode
-version = 3
+version = 4
 
 [TextureRedefine]
 width = 36

--- a/Mods/BreathOfTheWild_StaticFPS/rules.txt
+++ b/Mods/BreathOfTheWild_StaticFPS/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Static FPS Mod
 path = "The Legend of Zelda: Breath of the Wild/Mods/Static FPS Mod"
 description = "Simplified FPS++ to keep behavior closer to the default game. Don't mix dynamic and static mods. It requires that you can maintain the target FPS."
-version = 3
+version = 4
 
 [Preset]
 name = Static 45FPS

--- a/Mods/BreathOfTheWild_Weather/rules.txt
+++ b/Mods/BreathOfTheWild_Weather/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
 name = Weather
 path = "The Legend of Zelda: Breath of the Wild/Mods/Weather"
 description = Changes the weather
-version = 3
+version = 4
 
 [Preset]
 name = Clear weather


### PR DESCRIPTION
For packs without shaders, this is just changing the version field to 4. For all others the shaders need to be updated. The experimental Vulkan renderer will only load custom shaders if the version is set to 4.

Updating shaders mainly involves replacing the input/outputs (textures, attributes, uniforms) with the new header generated by Cemu 1.15.19 and WIP 1.16.0. In some cases parts of the main() code need to adjusted as well (e.g. use new macros for gl_FragCoord, gl_Position, gl_VertexID, gl_InstanceID)

I included an updated Clarity shader as an example in this commit.