### PR TITLE
[BOTW] add rendererFilter to LWZX Crash Pack

### DIFF
--- a/Workarounds/BreathOfTheWild_LwzxNullCheck/rules.txt
+++ b/Workarounds/BreathOfTheWild_LwzxNullCheck/rules.txt
@@ -1,5 +1,6 @@
 [Definition]
 titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
-path = "The Legend of Zelda: Breath of the Wild/Workarounds/LWZX Crash"
+path = "The Legend of Zelda: Breath of the Wild/Workarounds/LWZX Crash (OpenGL)"
 description = You should enable this pack in any circumstance. This workaround fixes crashes that would occur at specific points in the game.
-version = 3
+version = 4
+rendererFilter=opengl

--- a/Workarounds/BreathOfTheWild_LwzxNullCheck/rules.txt
+++ b/Workarounds/BreathOfTheWild_LwzxNullCheck/rules.txt
@@ -1,6 +1,6 @@
 [Definition]
 titleIds = 00050000101C9300,00050000101C9400,00050000101C9500
-path = "The Legend of Zelda: Breath of the Wild/Workarounds/LWZX Crash (OpenGL)"
+path = "The Legend of Zelda: Breath of the Wild/Workarounds/LWZX Crash"
 description = You should enable this pack in any circumstance. This workaround fixes crashes that would occur at specific points in the game.
 version = 4
 rendererFilter=opengl


### PR DESCRIPTION
add "(OpenGL)" to title and rendererFilter to this pack since it creates crashes on vulkan and is not nessecary due enforcement of GX2DrawDone on vulkan