### PR TITLE
Update XCX packs for Vulkan

### DIFF
--- a/Enhancements/XenobladeX_AntiAliasing/59df1c7e1806366c_00000000000003c9_ps.txt
+++ b/Enhancements/XenobladeX_AntiAliasing/59df1c7e1806366c_00000000000003c9_ps.txt
@@ -14,8 +14,17 @@
 #define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
 #define SET_POSITION(_v) gl_Position = _v
 #endif
-// This shaders was auto-converted from OpenGL to Cemu so expect weird code and possible errors.
-
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[2];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+// This shaders was auto-converted (and manually adjusted) from OpenGL to Cemu so expect weird code and possible errors.
 
 // shader 59df1c7e1806366c - Anti-aliasing Shader - Dumped 1.14
 
@@ -47,19 +56,8 @@ passPixelColor0 = texture(textureUnitPS1, passParameterSem1.xy); // textureunitp
 #endif
 
 #if (preset == 1) // Native AA Enabled
-
-#ifdef VULKAN
-layout(set = 1, binding = 6) uniform ufBlock
-{
-uniform ivec4 uf_remappedPS[2];
-uniform vec4 uf_fragCoordScale;
-};
-#else
-uniform ivec4 uf_remappedPS[2];
-uniform vec2 uf_fragCoordScale;
-#endif
-TEXTURE_LAYOUT(0, 1, 2) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e12000 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1
-TEXTURE_LAYOUT(1, 1, 3) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e12000 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
@@ -1155,8 +1153,8 @@ FxaaFloat4 FxaaPixelShader(
 //----------------------------------------------------------------------------------
 //#version 100
 
-TEXTURE_LAYOUT(0, 1, 4) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e12000 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1
-TEXTURE_LAYOUT(1, 1, 5) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e12000 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;

--- a/Enhancements/XenobladeX_Contrasty/59df1c7e1806366c_00000000000003c9_ps.txt
+++ b/Enhancements/XenobladeX_Contrasty/59df1c7e1806366c_00000000000003c9_ps.txt
@@ -1,10 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 59df1c7e1806366c
 //contrasty AA shader
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+uniform ivec4 uf_remappedPS[2];
+};
+#else
 uniform vec2 uf_fragCoordScale;
+uniform ivec4 uf_remappedPS[2];
+#endif
 
 const float hazeFactor = 0.1;
 
@@ -94,9 +120,9 @@ vec3 contrasty(vec3 colour){
 }
 
 
-uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e12000 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+// uf_remappedPS[2] was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;

--- a/Enhancements/XenobladeX_Contrasty/rules.txt
+++ b/Enhancements/XenobladeX_Contrasty/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
 name = Contrasty
 path = "Xenoblade Chronicles X/Enhancements/Contrasty" 
 description = This pack tweaks the colours and contrast to whatever preset you set it as. You can also make your own preset by editing the Default preset in the Contrasty folder from the game's graphic packs. Enabling will ignore your other AA settings.
-version = 3
+version = 4
 
 [Preset]
 name = High Contrasty - shadow lift

--- a/Enhancements/XenobladeX_FancyFX/5eb82314ffb8484e_00000000000007f9_ps.txt
+++ b/Enhancements/XenobladeX_FancyFX/5eb82314ffb8484e_00000000000007f9_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 5eb82314ffb8484e
 //cross fade blur prel
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[7];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e12000 res 320x180x1 dim 1 tm: 4 format 0820 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[7];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/XenobladeX_FancyFX/840947e29015aa9a_00000000000003c9_ps.txt
+++ b/Enhancements/XenobladeX_FancyFX/840947e29015aa9a_00000000000003c9_ps.txt
@@ -1,6 +1,23 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 840947e29015aa9a
 //BB cliff
 
@@ -10,24 +27,33 @@ const float scaleBlur = $scaleBlur;
 
 const int sampleScale = 4;
 
-highp float lineRand(vec2 co)
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4386000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 
 // FabriceNeyret2 CC, single shader gaussian by intermediate MIPmap level. www.shadertoy.com/view/ltScRG
 const int samples = 8 * sampleScale, //8 or 4 balances xy position

--- a/Enhancements/XenobladeX_FancyFX/_810cde937ebbdf9f_000000000000000f_ps.txt
+++ b/Enhancements/XenobladeX_FancyFX/_810cde937ebbdf9f_000000000000000f_ps.txt
@@ -9,13 +9,13 @@ layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
 uniform vec2 uf_fragCoordScale;
 
-highp float lineRand(vec2 co)
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
 

--- a/Enhancements/XenobladeX_FancyFX/b3fb199c73caa796_00000000000003c9_ps.txt
+++ b/Enhancements/XenobladeX_FancyFX/b3fb199c73caa796_00000000000003c9_ps.txt
@@ -1,6 +1,23 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader b3fb199c73caa796
 //BB title
 
@@ -11,22 +28,31 @@ const float scaleBlur = $scaleBlur;
 
 const int sampleScale = 4;
 const float lightBloom = 0.95; 
-highp float lineRand(vec2 co)
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[4];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf551a000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[4];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 
 // FabriceNeyret2 CC, single shader gaussian by intermediate MIPmap level. www.shadertoy.com/view/ltScRG
 const int samples = 8 * sampleScale, //8 or 4 balances xy position

--- a/Enhancements/XenobladeX_FancyFX/d8e69e8df8c227f5_00000000000003c9_ps.txt
+++ b/Enhancements/XenobladeX_FancyFX/d8e69e8df8c227f5_00000000000003c9_ps.txt
@@ -1,6 +1,23 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader d8e69e8df8c227f5
 //BB grid n char select
 const float dither = $dither ;
@@ -10,24 +27,33 @@ const float scaleBlur = $scaleBlur;
 
 const int sampleScale = 4;
 const float lightBloom = 0.95; 
-highp float lineRand(vec2 co)
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
 
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4386000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 
 // FabriceNeyret2 CC, single shader gaussian by intermediate MIPmap level. www.shadertoy.com/view/ltScRG
 const int samples = 8 * sampleScale, //8 or 4 balances xy position

--- a/Enhancements/XenobladeX_FancyFX/e412d30f981be3b5_0000000000000000_vs.txt
+++ b/Enhancements/XenobladeX_FancyFX/e412d30f981be3b5_0000000000000000_vs.txt
@@ -1,14 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader e412d30f981be3b5
 //stasis cinematic align. A compromise for centering pretty blur
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -54,7 +79,7 @@ backupReg1f = R2f.y;
 R2f.x = (backupReg0f * intBitsToFloat(uf_remappedVS[0].x) + intBitsToFloat(uf_remappedVS[0].z)*0.5);//edit
 R2f.y = (backupReg1f * intBitsToFloat(uf_remappedVS[0].y) + intBitsToFloat(uf_remappedVS[0].w)*0.5);
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem0 = vec4(R2f.x, R2f.y, R2f.z, R2f.z);
 // 0

--- a/Enhancements/XenobladeX_FancyFX/rules.txt
+++ b/Enhancements/XenobladeX_FancyFX/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
 name = Fancy GFX # I would have called this RTX on, but Nvidia has trademarked it ;)
 path = "Xenoblade Chronicles X/Enhancements/Fancy FX" 
 description = Pretty blur, de-band sky, re-align cinematic etc, maintained on Nvidia.   
-version = 3
+version = 4
 
 #Disabled, causes gfx errors on 1.15.x  Enable if fixed. 
 #[TextureRedefine] 

--- a/Resolutions/XenobladeX_Resolution/007148d1db7f78e7_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/007148d1db7f78e7_0000000000000000_vs.txt
@@ -1,23 +1,48 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 007148d1db7f78e7
 //fog clouds
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
-layout(location = 11) in uvec4 attrDataSem11;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
+ATTR_LAYOUT(0, 11) in uvec4 attrDataSem11;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1397,7 +1422,7 @@ R1i.w = floatBitsToInt(mul_nonIEEE(intBitsToFloat(R127i.x), intBitsToFloat(uf_re
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/0b8b33c2f133a514_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/0b8b33c2f133a514_0000000000000000_vs.txt
@@ -1,21 +1,46 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 0b8b33c2f133a514
 //transport flame 3 *dumped*
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1367,7 +1392,7 @@ R1i.z = floatBitsToInt((intBitsToFloat(R126i.y) * intBitsToFloat(uf_remappedVS[2
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/0dbac1e3ebdc5c02_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/0dbac1e3ebdc5c02_0000000000000000_vs.txt
@@ -1,20 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 0dbac1e3ebdc5c02
 // float arrow ingame *dumped*
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1350,7 +1375,7 @@ R1i.z = floatBitsToInt((intBitsToFloat(R126i.y) * intBitsToFloat(uf_remappedVS[2
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R0i.x) *(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x) *(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/14f760ff4d6b05f5_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/14f760ff4d6b05f5_0000000000000000_vs.txt
@@ -1,19 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 14f760ff4d6b05f5
 //muzzle flash
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[24];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem6;
-layout(location = 6) in uvec4 attrDataSem7;
-layout(location = 7) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[24];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -289,7 +314,7 @@ PS1i = R6i.x;
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R2i.x)*(origRatio / newRatio), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+SET_POSITION(vec4(intBitsToFloat(R2i.x)*(origRatio / newRatio), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w)));
 // 0
 tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.y),intBitsToFloat(R7i.z),-0.0),vec4(intBitsToFloat(R7i.x),intBitsToFloat(R7i.y),intBitsToFloat(R5i.z),0.0)));
 PV0i.x = tempi.x;

--- a/Resolutions/XenobladeX_Resolution/1f915b133a255dab_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/1f915b133a255dab_0000000000000000_vs.txt
@@ -1,12 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 1f915b133a255dab
 //battle graph, dumped
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
 uniform float uf_alphaTestRef;
-layout(location = 0) in uvec4 attrDataSem0;
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+uniform float uf_alphaTestRef;
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+// uf_alphaTestRef was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -198,7 +225,7 @@ R2i.w = floatBitsToInt((intBitsToFloat(uf_uniformRegisterVS[ARi.x+8].z) * intBit
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R1i.x)*(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+SET_POSITION(vec4(intBitsToFloat(R1i.x)*(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/20075cc6cf058a84_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/20075cc6cf058a84_0000000000000000_vs.txt
@@ -1,19 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 20075cc6cf058a84
 // skell intro smoke
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[26];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[26];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1270,7 +1295,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height));
 // *(origRatio / newRatio)
 
-gl_Position = vec4(intBitsToFloat(R10i.x)*(origRatio / newRatio), intBitsToFloat(R10i.y), intBitsToFloat(R10i.z), intBitsToFloat(R10i.w));
+SET_POSITION(vec4(intBitsToFloat(R10i.x)*(origRatio / newRatio), intBitsToFloat(R10i.y), intBitsToFloat(R10i.z), intBitsToFloat(R10i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/21eafb6c514a4b35_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/21eafb6c514a4b35_0000000000000000_vs.txt
@@ -1,23 +1,48 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 21eafb6c514a4b35
 //flash creature
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
-layout(location = 11) in uvec4 attrDataSem11;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
+ATTR_LAYOUT(0, 11) in uvec4 attrDataSem11;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1384,7 +1409,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 
-gl_Position = vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/2716141e287247da_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/2716141e287247da_0000000000000000_vs.txt
@@ -1,21 +1,46 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 2716141e287247da
 //transport heat waves, desert
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[21];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[21];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1284,7 +1309,7 @@ R0i.w = ((PV0i.x == 0)?(backupReg1i):(0x3f800000));
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/330acac562ddee2b_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/330acac562ddee2b_0000000000000000_vs.txt
@@ -1,20 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 330acac562ddee2b // waterfall splash closeup
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1378,7 +1403,7 @@ R1i.w = floatBitsToInt(intBitsToFloat(R127i.x) * intBitsToFloat(uf_remappedVS[19
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 
-gl_Position = vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/3fae14064195391b_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/3fae14064195391b_0000000000000000_vs.txt
@@ -1,22 +1,47 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 3fae14064195391b
 //ockserve engine late game
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[21];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[21];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1286,7 +1311,7 @@ float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 
 // export
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/4c66e611ad14aabe_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/4c66e611ad14aabe_0000000000000000_vs.txt
@@ -1,18 +1,43 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 4c66e611ad14aabe
 //intro dive splash
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[24];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem5;
-layout(location = 5) in uvec4 attrDataSem6;
-layout(location = 6) in uvec4 attrDataSem7;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[24];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem7;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -280,7 +305,7 @@ PS1i = R8i.z;
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R2i.x)*(origRatio / newRatio), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+SET_POSITION(vec4(intBitsToFloat(R2i.x)*(origRatio / newRatio), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w)));
 // 0
 tempi.x = floatBitsToInt(dot(vec4(intBitsToFloat(R1i.x),intBitsToFloat(R1i.y),intBitsToFloat(R6i.z),-0.0),vec4(intBitsToFloat(R6i.x),intBitsToFloat(R6i.y),intBitsToFloat(R4i.z),0.0)));
 PV0i.x = tempi.x;

--- a/Resolutions/XenobladeX_Resolution/5a41baf724c1cff3_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/5a41baf724c1cff3_0000000000000000_vs.txt
@@ -1,20 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 5a41baf724c1cff3 // reflection water crystal
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1379,7 +1404,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R4i.x) *(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x) *(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/6093720c5ca6289c_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/6093720c5ca6289c_0000000000000000_vs.txt
@@ -1,17 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 6093720c5ca6289c
 //lensflare
+#ifdef VULKAN
+layout(set = 0, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[8];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(binding = 32) uniform sampler2D textureUnitVS0;// Tex0 addr 0xf5f0a000 res 640x360x1 dim 1 tm: 4 format 080e compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler18 ClampX/Y/Z: 2 2 2 border: 0
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[8];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+TEXTURE_LAYOUT(32, 0, 0) uniform sampler2D textureUnitVS0;
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -508,7 +533,7 @@ R0i.w = ((PV1i.z == 0)?(R9i.y):(0x3f800000));
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/610a9c4cb60b0bdf_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/610a9c4cb60b0bdf_0000000000000000_vs.txt
@@ -1,18 +1,43 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 610a9c4cb60b0bdf
 //flashlight
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[13];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem5;
-layout(location = 5) in uvec4 attrDataSem6;
-layout(location = 6) in uvec4 attrDataSem7;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[13];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem7;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -266,7 +291,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 
-gl_Position = vec4(intBitsToFloat(R1i.x)*(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+SET_POSITION(vec4(intBitsToFloat(R1i.x)*(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/622450648ddbf1b2_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/622450648ddbf1b2_0000000000000000_vs.txt
@@ -1,18 +1,43 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 622450648ddbf1b2 //car lights (float vs?)
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[10];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[10];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -449,7 +474,7 @@ R2i.z = floatBitsToInt(-(intBitsToFloat(PV1i.x)));
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 
-gl_Position = vec4(intBitsToFloat(R3i.x)*(origRatio / newRatio), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+SET_POSITION(vec4(intBitsToFloat(R3i.x)*(origRatio / newRatio), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R6i.x), intBitsToFloat(R6i.y), intBitsToFloat(R6i.z), intBitsToFloat(R6i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/738c509776f2c113_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/738c509776f2c113_0000000000000000_vs.txt
@@ -1,18 +1,43 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 738c509776f2c113 // front lights
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[10];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[10];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -451,7 +476,7 @@ R2i.z = floatBitsToInt(-(intBitsToFloat(PV1i.x)));
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 
-gl_Position = vec4(intBitsToFloat(R3i.x)*(origRatio / newRatio), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
+SET_POSITION(vec4(intBitsToFloat(R3i.x)*(origRatio / newRatio), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R6i.x), intBitsToFloat(R6i.y), intBitsToFloat(R6i.z), intBitsToFloat(R6i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/7d2d26ba00a66735_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/7d2d26ba00a66735_0000000000000000_vs.txt
@@ -1,24 +1,49 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 7d2d26ba00a66735
 // waterfall cascade
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
-layout(location = 11) in uvec4 attrDataSem11;
-layout(location = 12) in uvec4 attrDataSem12;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
+ATTR_LAYOUT(0, 11) in uvec4 attrDataSem11;
+ATTR_LAYOUT(0, 12) in uvec4 attrDataSem12;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1398,7 +1423,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/7ec11ebc6ad99936_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/7ec11ebc6ad99936_0000000000000000_vs.txt
@@ -1,23 +1,48 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 7ec11ebc6ad99936
 //Raindrops opening scene
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
-layout(location = 11) in uvec4 attrDataSem11;
-layout(location = 12) in uvec4 attrDataSem12;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
+ATTR_LAYOUT(0, 11) in uvec4 attrDataSem11;
+ATTR_LAYOUT(0, 12) in uvec4 attrDataSem12;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1393,7 +1418,7 @@ R1i.z = floatBitsToInt((intBitsToFloat(R126i.y) * intBitsToFloat(uf_remappedVS[2
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/8236d4df96d36e25_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/8236d4df96d36e25_0000000000000000_vs.txt
@@ -1,19 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 8236d4df96d36e25
 //invation cutscene skell weapons
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[13];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem6;
-layout(location = 6) in uvec4 attrDataSem7;
-layout(location = 7) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[13];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -276,7 +301,7 @@ R3i.z = floatBitsToInt(max(intBitsToFloat(R4i.z), 0.0));
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R1i.x)*(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+SET_POSITION(vec4(intBitsToFloat(R1i.x)*(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/90bdbafc1c764ae6_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/90bdbafc1c764ae6_0000000000000000_vs.txt
@@ -1,22 +1,47 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 90bdbafc1c764ae6
 //sand storm clouds pot
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1380,7 +1405,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/948500d0191d1ed8_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/948500d0191d1ed8_0000000000000000_vs.txt
@@ -1,20 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 948500d0191d1ed8
 // invation cutscene skell lights 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[13];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem6;
-layout(location = 6) in uvec4 attrDataSem7;
-layout(location = 7) in uvec4 attrDataSem8;
-layout(location = 8) in uvec4 attrDataSem9;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[13];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem9;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -288,7 +313,7 @@ PS0i = R1i.z;
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R9i.x)*(origRatio / newRatio), intBitsToFloat(R9i.y), intBitsToFloat(R9i.z), intBitsToFloat(R9i.w));
+SET_POSITION(vec4(intBitsToFloat(R9i.x)*(origRatio / newRatio), intBitsToFloat(R9i.y), intBitsToFloat(R9i.z), intBitsToFloat(R9i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/9bc5e526132c9534_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/9bc5e526132c9534_0000000000000000_vs.txt
@@ -1,13 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 9bc5e526132c9534
 // selection fill *dumped*
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[11];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
 uniform float uf_alphaTestRef;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+};
+#else
+uniform ivec4 uf_remappedVS[11];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+uniform float uf_alphaTestRef;
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+// uf_alphaTestRef was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -131,7 +158,7 @@ R2f.w = (R127f.w * intBitsToFloat(uf_remappedVS[10].w) + PV1f.x);
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(R2f.x*(origRatio / newRatio), R2f.y, R2f.z, R2f.w);
+SET_POSITION(vec4(R2f.x*(origRatio / newRatio), R2f.y, R2f.z, R2f.w));
 // export
 passParameterSem0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
 // 0

--- a/Resolutions/XenobladeX_Resolution/9dc2d340255dee89_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/9dc2d340255dee89_0000000000000000_vs.txt
@@ -1,14 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 const float resXScale =  float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
 // shader 9dc2d340255dee89
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -54,7 +79,7 @@ backupReg1f = R2f.y;
 R2f.x = (backupReg0f * intBitsToFloat(uf_remappedVS[0].x) + intBitsToFloat(uf_remappedVS[0].z) /resXScale);
 R2f.y = (backupReg1f * intBitsToFloat(uf_remappedVS[0].y) + intBitsToFloat(uf_remappedVS[0].w) /resXScale);
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem0 = vec4(R2f.x, R2f.y, R2f.z, R2f.z);
 // 0

--- a/Resolutions/XenobladeX_Resolution/a225baec4db6d89e_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/a225baec4db6d89e_0000000000000000_vs.txt
@@ -1,22 +1,47 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader a225baec4db6d89e
 //flying trails desert
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1379,7 +1404,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R4i.x) *(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x) *(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/ba529c2c3078fff0_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/ba529c2c3078fff0_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader ba529c2c3078fff0 // rain engine glow // drop frame blend?
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[13];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem5;
-layout(location = 5) in uvec4 attrDataSem6;
-layout(location = 6) in uvec4 attrDataSem7;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[13];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem7;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -265,7 +290,7 @@ float newRatio = (float($width)/float($height)) ;
 
 
 // export
-gl_Position = vec4(intBitsToFloat(R1i.x)*(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+SET_POSITION(vec4(intBitsToFloat(R1i.x)*(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/c01cc5b7af21f689_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/c01cc5b7af21f689_0000000000000000_vs.txt
@@ -1,22 +1,47 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader c01cc5b7af21f689
 //fog skell flight
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1370,7 +1395,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/ccc475eb7e537add_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/ccc475eb7e537add_0000000000000000_vs.txt
@@ -1,18 +1,43 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader ccc475eb7e537add
 //motion streaks sword
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[22];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[22];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -524,7 +549,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R9i.x)*(origRatio / newRatio), intBitsToFloat(R9i.y), intBitsToFloat(R9i.z), intBitsToFloat(R9i.w));
+SET_POSITION(vec4(intBitsToFloat(R9i.x)*(origRatio / newRatio), intBitsToFloat(R9i.y), intBitsToFloat(R9i.z), intBitsToFloat(R9i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/ccc6fb8b53f5f651_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/ccc6fb8b53f5f651_0000000000000000_vs.txt
@@ -1,23 +1,48 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader ccc6fb8b53f5f651
 //flying enemies trails 2
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
-layout(location = 11) in uvec4 attrDataSem11;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
+ATTR_LAYOUT(0, 11) in uvec4 attrDataSem11;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1385,7 +1410,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/d0664898dbf28dfa_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/d0664898dbf28dfa_0000000000000000_vs.txt
@@ -1,11 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader d0664898dbf28dfa// Pillarbox cutscene fmvs 16:9 -> 21:9
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -65,7 +90,7 @@ R1f.w = 1.0;
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(R1f.x*(origRatio / newRatio), R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x*(origRatio / newRatio), R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem0 = vec4(R2f.x, R2f.y, R2f.z, R2f.z);
 // 0

--- a/Resolutions/XenobladeX_Resolution/d321199dc854621f_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/d321199dc854621f_0000000000000000_vs.txt
@@ -1,20 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader d321199dc854621f
 //flying enemies trails
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[26];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[26];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1257,7 +1282,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R10i.x)*(origRatio / newRatio), intBitsToFloat(R10i.y), intBitsToFloat(R10i.z), intBitsToFloat(R10i.w));
+SET_POSITION(vec4(intBitsToFloat(R10i.x)*(origRatio / newRatio), intBitsToFloat(R10i.y), intBitsToFloat(R10i.z), intBitsToFloat(R10i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/d7074f19f5ca3b20_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/d7074f19f5ca3b20_0000000000000000_vs.txt
@@ -1,14 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader d7074f19f5ca3b20
 //tower counter 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[14];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[14];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -246,7 +271,7 @@ PS1i = R2i.x;
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R1i.x) *(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+SET_POSITION(vec4(intBitsToFloat(R1i.x) *(origRatio / newRatio), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w)));
 // export
 passParameterSem1 = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.z));
 // 0

--- a/Resolutions/XenobladeX_Resolution/df832bc2e6d22e45_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/df832bc2e6d22e45_0000000000000000_vs.txt
@@ -1,20 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader df832bc2e6d22e45 // water splash drinking
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1365,7 +1390,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/dfacd3f8f448aeaa_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/dfacd3f8f448aeaa_0000000000000000_vs.txt
@@ -1,17 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader dfacd3f8f448aeaa // car lights streaks
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[26];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[26];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1251,7 +1276,7 @@ R0i.z = floatBitsToInt((intBitsToFloat(R127i.x) * intBitsToFloat(uf_remappedVS[2
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 
-gl_Position = vec4(intBitsToFloat(R12i.x)*(origRatio / newRatio), intBitsToFloat(R12i.y), intBitsToFloat(R12i.z), intBitsToFloat(R12i.w));
+SET_POSITION(vec4(intBitsToFloat(R12i.x)*(origRatio / newRatio), intBitsToFloat(R12i.y), intBitsToFloat(R12i.z), intBitsToFloat(R12i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/e082c1f638f8e81e_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/e082c1f638f8e81e_0000000000000000_vs.txt
@@ -1,24 +1,49 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader e082c1f638f8e81e
 //mask is probably scaled and fixed transparency
 // transport flame,   fog and quest marking, waterfall, computer login
 
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1354,7 +1379,7 @@ R1i.z = floatBitsToInt((intBitsToFloat(R126i.y) * intBitsToFloat(uf_remappedVS[2
 
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/e99ed318f647e1cf_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/e99ed318f647e1cf_0000000000000000_vs.txt
@@ -1,20 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader e99ed318f647e1cf // skell lights opening
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1365,7 +1390,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 
-gl_Position = vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x)*(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/ec248df3384d3d18_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/ec248df3384d3d18_0000000000000000_vs.txt
@@ -1,20 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader ec248df3384d3d18
 //run dust and shadows intro
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem9;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem9;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1310,7 +1335,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(intBitsToFloat(R0i.x) *(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
+SET_POSITION(vec4(intBitsToFloat(R0i.x) *(origRatio / newRatio), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R3i.x), intBitsToFloat(R3i.y), intBitsToFloat(R3i.z), intBitsToFloat(R3i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/eec2c2cee7a1d42f_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/eec2c2cee7a1d42f_0000000000000000_vs.txt
@@ -1,21 +1,46 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader eec2c2cee7a1d42f
 //waterfall splashes cutscene, rain *dumped*
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[27];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
-layout(location = 4) in uvec4 attrDataSem4;
-layout(location = 5) in uvec4 attrDataSem5;
-layout(location = 6) in uvec4 attrDataSem6;
-layout(location = 7) in uvec4 attrDataSem7;
-layout(location = 8) in uvec4 attrDataSem8;
-layout(location = 9) in uvec4 attrDataSem9;
-layout(location = 10) in uvec4 attrDataSem10;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[27];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 5) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 6) in uvec4 attrDataSem6;
+ATTR_LAYOUT(0, 7) in uvec4 attrDataSem7;
+ATTR_LAYOUT(0, 8) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 9) in uvec4 attrDataSem9;
+ATTR_LAYOUT(0, 10) in uvec4 attrDataSem10;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -1378,7 +1403,7 @@ R1i.w = floatBitsToInt(intBitsToFloat(R127i.x) * intBitsToFloat(uf_remappedVS[19
 float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
-gl_Position = vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x)*(origRatio / newRatio), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.w));
 // export

--- a/Resolutions/XenobladeX_Resolution/fa7054d25fd49999_0000000000000000_vs.txt
+++ b/Resolutions/XenobladeX_Resolution/fa7054d25fd49999_0000000000000000_vs.txt
@@ -1,13 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader fa7054d25fd49999
 //lock line combat
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[4];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[4];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -99,7 +124,7 @@ float origRatio = (float(1280)/float(720));
 float newRatio = (float($width)/float($height)) ;
 // *(origRatio / newRatio)
 // export
-gl_Position = vec4(R0f.x*(origRatio / newRatio), R0f.y, R0f.z, R0f.w);
+SET_POSITION(vec4(R0f.x*(origRatio / newRatio), R0f.y, R0f.z, R0f.w));
 // export
 passParameterSem0 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
 // export

--- a/Resolutions/XenobladeX_Resolution/fdb5a87dd0368c6b_000000000000f249_ps.txt
+++ b/Resolutions/XenobladeX_Resolution/fdb5a87dd0368c6b_000000000000f249_ps.txt
@@ -1,18 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 const float resXScale =  float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
 // shader fdb5a87dd0368c6b //shadow scaling
+#ifdef VULKAN
+layout(set = 1, binding = 4) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[23];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4386000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2DShadow textureUnitPS1;// Tex1 addr 0xf551a000 res 1024x1024x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 6 6 6 border: 2
-layout(binding = 2) uniform sampler2DShadow textureUnitPS2;// Tex2 addr 0xf571a000 res 1024x1024x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 6 6 6 border: 2
-layout(binding = 3) uniform sampler2DShadow textureUnitPS3;// Tex3 addr 0xf591a000 res 512x512x1 dim 1 tm: 4 format 0005 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 6 6 6 border: 2
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[23];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2DShadow textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2DShadow textureUnitPS2;
+TEXTURE_LAYOUT(3, 1, 3) uniform sampler2DShadow textureUnitPS3;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/XenobladeX_Resolution/rules.txt
+++ b/Resolutions/XenobladeX_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
 name = Resolution
 path = "Xenoblade Chronicles X/Graphics/Resolution"
 description = Changes the resolution of the game. 
-version = 3
+version = 4
 
 
 [Preset]

--- a/Workarounds/XenobladeX_Brightness/3cc7e98f78c258b4_00000000000003ca_ps.txt
+++ b/Workarounds/XenobladeX_Brightness/3cc7e98f78c258b4_00000000000003ca_ps.txt
@@ -1,5 +1,22 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 3cc7e98f78c258b4 // brightness workaround. 
 // To-do, .5 is daylight and 1.0 night is wiiu "correct" for nvidia
 // changes here in turn "breaks" bloom as they over or under expose depending on day/night 
@@ -28,20 +45,29 @@ vec3 contrasty(vec3 colour){
 }
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
 
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler3D textureUnitPS1;// Tex1 addr 0x2603b000 res 16x16x16 dim 2 tm: 7 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x10) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler3D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
-highp float lineRand(vec2 co)
+// uf_fragCoordScale was moved to the ufBlock
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
 

--- a/Workarounds/XenobladeX_Brightness/7b9f05b2bd8f3b71_0000000000000079_ps.txt
+++ b/Workarounds/XenobladeX_Brightness/7b9f05b2bd8f3b71_0000000000000079_ps.txt
@@ -1,6 +1,23 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader 7b9f05b2bd8f3b71
 //skell cockpit brigthtness fix + minor colour tweak to balance broken bloom
 const float exposure = $exposure; // 1.0 is neutral, first lessen to avoid truncation prob around .25 for radeon. 
@@ -10,11 +27,20 @@ const float vibrance = $vibrance;  // 0.0 is neutral
 const float crushContrast = $crushContrast; // 0.0 is neutral. loss of shadow detail 
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 
 
 vec3 contrasty(vec3 colour) {

--- a/Workarounds/XenobladeX_Brightness/bd74794730fc559a_00000000ff249249_ps.txt
+++ b/Workarounds/XenobladeX_Brightness/bd74794730fc559a_00000000ff249249_ps.txt
@@ -1,25 +1,51 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader bd74794730fc559a
 //tweak glare, less J.J. Abrams 
 const float glare = $glare; //reflection on skell, characters, metal objects etc
+#ifdef VULKAN
+layout(set = 1, binding = 8) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[12];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf5196000 res 1280x720x1 dim 1 tm: 4 format 0810 compSel: 0 1 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4386000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0xf5d48000 res 1x1x1 dim 1 tm: 2 format 0008 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 3) uniform sampler2D textureUnitPS3;// Tex3 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 041a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 4) uniform sampler2D textureUnitPS4;// Tex4 addr 0xf4a8e000 res 1280x720x1 dim 1 tm: 4 format 041a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler4 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 5) uniform sampler2D textureUnitPS5;// Tex5 addr 0xf4e12000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler5 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 7) uniform sampler2D textureUnitPS7;// Tex7 addr 0xf589e000 res 640x360x1 dim 1 tm: 4 format 0007 compSel: 0 1 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler7 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 9) uniform sampler2D textureUnitPS9;// Tex9 addr 0xf5ff0000 res 64x64x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler9 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[12];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
+TEXTURE_LAYOUT(3, 1, 3) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(4, 1, 4) uniform sampler2D textureUnitPS4;
+TEXTURE_LAYOUT(5, 1, 5) uniform sampler2D textureUnitPS5;
+TEXTURE_LAYOUT(7, 1, 6) uniform sampler2D textureUnitPS7;
+TEXTURE_LAYOUT(9, 1, 7) uniform sampler2D textureUnitPS9;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 2) in vec4 passParameterSem2;
 layout(location = 3) in vec4 passParameterSem3;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Workarounds/XenobladeX_Brightness/d936195db0dd8e7d_0000000000001e52_ps.txt
+++ b/Workarounds/XenobladeX_Brightness/d936195db0dd8e7d_0000000000001e52_ps.txt
@@ -1,5 +1,22 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shaders was auto-converted from OpenGL to Cemu.
+
 // shader d936195db0dd8e7d 
 // cross fade brightness
 // To-do, .5 is daylight and 1.0 night is wiiu "correct" for nvidia
@@ -28,21 +45,30 @@ vec3 contrasty(vec3 colour){
 	return fColour;
 }
 
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler3D textureUnitPS1;// Tex1 addr 0x26032000 res 16x16x16 dim 2 tm: 7 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x10) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 2) uniform sampler3D textureUnitPS2;// Tex2 addr 0x2603b000 res 16x16x16 dim 2 tm: 7 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x10) Sampler2 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler3D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler3D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 
-highp float lineRand(vec2 co)
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
 

--- a/Workarounds/XenobladeX_Brightness/rules.txt
+++ b/Workarounds/XenobladeX_Brightness/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010116100,00050000101C4C00,00050000101C4D00
 name = Brightness Workaround
 path = "Xenoblade Chronicles X/Workarounds/Brightness"
 description = Edit presets for preference.
-version = 3
+version = 4
 
 [Preset]
 name = NVIDIA

--- a/docs/v4-converter/convert-packs.js
+++ b/docs/v4-converter/convert-packs.js
@@ -518,7 +518,7 @@ function convertFolder(folderPathArray) {
 	if (fs.existsSync(path.join(process.cwd(), "/graphicPacks/", ...folderPathArray))) fs.rmdirSync(path.join(process.cwd(), "/graphicPacks/", ...folderPathArray), {recursive: true});
 	fs.mkdirSync(path.join(process.cwd(), "/graphicPacks/", ...folderPathArray), {recursive: true});
 	
-	for (entry in dirEntries) {
+	for (let entry in dirEntries) {
 		if (dirEntries[entry].isDirectory()) {
 			// Check for folder entries and see if there's a rules.txt file.
 			let packFiles = fs.readdirSync(path.join(process.cwd(), ...folderPathArray, dirEntries[entry].name), {withFileTypes: true});

--- a/docs/v4-converter/verify-graphicPacks.js
+++ b/docs/v4-converter/verify-graphicPacks.js
@@ -244,7 +244,7 @@ function verifyPack(analyseFiles, folderArray) {
 function verifyGraphicPacks(folderArray) {
 	let dirEntries = fs.readdirSync(path.join(process.cwd(), ...folderArray), {withFileTypes: true});
 	
-	for (entry in dirEntries) {
+	for (let entry in dirEntries) {
 		if (dirEntries[entry].isDirectory()) {
 			console.group("Verify "+path.join(process.cwd(), ...folderArray, dirEntries[entry].name));
 


### PR DESCRIPTION
Everything was verified with my shader dump and no shader wasn't verified. So every shader in here should be working.

I was getting some warnings from glslangValidator about some code snippet that was more aimed at OpenGL ES (that's the context I found the code snippet was used online in at least). Since desktop GPU's always use high accuracy data types, it makes sense to just use the normal data types. Here's the code snippet though:
```glsl
highp float lineRand(vec2 co)
{
	highp float a = 12.9898;
	highp float b = 78.233;
	highp float c = 43758.5453;
	highp float dt = dot(co.xy, vec2(a, b));
	highp float sn = mod(dt, 3.14);
	return fract(sin(sn) * c);
}
```