### PR TITLE
Convert a lot of graphic packs to V4

### DIFF
--- a/Enhancements/Bayonetta_Contrasty/21e6bc9b0cdbe8d7_00000000000003c9_ps.txt
+++ b/Enhancements/Bayonetta_Contrasty/21e6bc9b0cdbe8d7_00000000000003c9_ps.txt
@@ -1,10 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 21e6bc9b0cdbe8d7
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[3];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
 uniform vec2 uf_fragCoordScale;
+#endif
 
 const float hazeFactor = $hazeFactor;
 
@@ -94,9 +120,9 @@ vec3 contrasty(vec3 colour){
 }
 
 
-uniform ivec4 uf_remappedPS[3];
-layout(binding = 3) uniform sampler2D textureUnitPS3;// Tex3 addr 0xf5195800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 0 0 0 border: 0
-layout(binding = 4) uniform sampler2D textureUnitPS4;// Tex4 addr 0xf5d81800 res 256x1x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler4 ClampX/Y/Z: 2 2 0 border: 0
+// uf_remappedPS[3] was moved to the ufBlock
+TEXTURE_LAYOUT(3, 1, 0) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(4, 1, 1) uniform sampler2D textureUnitPS4;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
 //uniform vec2 uf_fragCoordScale;

--- a/Enhancements/Bayonetta_Contrasty/rules.txt
+++ b/Enhancements/Bayonetta_Contrasty/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001014DB00,0005000010157E00,0005000010157F00
 name = Contrasty
 path = "Bayonetta/Enhancements/Contrasty"
 description = This pack tweaks the colors and contrast to whatever preset you set it as. You can also make your own preset by editing the Default preset in the Contrasty folder from the game's graphic packs. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = Default

--- a/Enhancements/DonkeyKongTropicalFreeze_!AARemoval/10ccf0cc1234d069_00000000000003c9_ps.txt
+++ b/Enhancements/DonkeyKongTropicalFreeze_!AARemoval/10ccf0cc1234d069_00000000000003c9_ps.txt
@@ -1,12 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 10ccf0cc1234d069 // AA removal cemu 1.8
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf55ae800 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4708800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/DonkeyKongTropicalFreeze_!AARemoval/bafe6c9c37bfca4d_00000000000003c9_ps.txt
+++ b/Enhancements/DonkeyKongTropicalFreeze_!AARemoval/bafe6c9c37bfca4d_00000000000003c9_ps.txt
@@ -1,12 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader bafe6c9c37bfca4d // AA removal cemu 1.8 version
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf55ae800 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4708800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/DonkeyKongTropicalFreeze_!AARemoval/rules.txt
+++ b/Enhancements/DonkeyKongTropicalFreeze_!AARemoval/rules.txt
@@ -3,4 +3,4 @@ titleIds = 0005000010137F00,0005000010138300,0005000010144800
 name = AA Removal
 path = "Donkey Kong Country: Tropical Freeze/Enhancements/AA Removal" 
 description = Removes AA, no performance gain. Used for clean look or injecting external AA.
-version = 3
+version = 4

--- a/Enhancements/DrLuigi_!AntiAliasing/9e9abde99f9510dc_000000000000001c_ps.txt
+++ b/Enhancements/DrLuigi_!AntiAliasing/9e9abde99f9510dc_000000000000001c_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 9e9abde99f9510dc
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform float uf_alphaTestRef;
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf489e000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform float uf_alphaTestRef;
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem129;
 layout(location = 1) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/DrLuigi_!AntiAliasing/rules.txt
+++ b/Enhancements/DrLuigi_!AntiAliasing/rules.txt
@@ -3,4 +3,4 @@ titleIds = 0005000010150300,0005000010152A00,0005000010152B00
 name = Anti-Aliasing
 path = "Dr. Luigi/Graphics/Anti-Aliasing (WIP)"
 description = Re-enables the game's anti-aliasing and scales it up to the current resolution. Made by Slashiee.
-version = 3
+version = 4

--- a/Enhancements/HyruleWarriors_Contrasty/572a6cfa3943923d_0000000000001e49_ps.txt
+++ b/Enhancements/HyruleWarriors_Contrasty/572a6cfa3943923d_0000000000001e49_ps.txt
@@ -1,10 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 572a6cfa3943923d
 //ingame contrasty
 
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[5];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[5];
 uniform vec2 uf_fragCoordScale;
+#endif
 
 const float hazeFactor = 0.1;
 
@@ -94,10 +120,10 @@ vec3 contrasty(vec3 colour){
 }
 
 
-uniform ivec4 uf_remappedPS[5];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e13800 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x1abf4800 res 1x1x1 dim 1 tm: 2 format 080e compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x1abdd800 res 160x90x1 dim 1 tm: 4 format 041a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 2 2 2 border: 0
+// uf_remappedPS[5] was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
 //uniform vec2 uf_fragCoordScale;

--- a/Enhancements/HyruleWarriors_Contrasty/6ea8b1aa69c0b6f7_0000000001e49249_ps.txt
+++ b/Enhancements/HyruleWarriors_Contrasty/6ea8b1aa69c0b6f7_0000000001e49249_ps.txt
@@ -1,10 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 6ea8b1aa69c0b6f7
 //cutscene contrasty
 
+#ifdef VULKAN
+layout(set = 1, binding = 7) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[5];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[5];
 uniform vec2 uf_fragCoordScale;
+#endif
 
 const float hazeFactor = 0.1;
 
@@ -94,14 +120,14 @@ vec3 contrasty(vec3 colour){
 }
 
 
-uniform ivec4 uf_remappedPS[5];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e13800 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x1b163800 res 512x1x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 3) uniform sampler2D textureUnitPS3;// Tex3 addr 0x10ea5000 res 1280x720x1 dim 1 tm: 4 format 0011 compSel: 0 0 0 0 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 4) uniform sampler2D textureUnitPS4;// Tex4 addr 0x1aff9000 res 320x180x1 dim 1 tm: 4 format 0820 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler4 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 5) uniform sampler2D textureUnitPS5;// Tex5 addr 0x1b072000 res 320x180x1 dim 1 tm: 4 format 0820 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler5 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 6) uniform sampler2D textureUnitPS6;// Tex6 addr 0x1b17b000 res 1x1x1 dim 1 tm: 2 format 080e compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler6 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 7) uniform sampler2D textureUnitPS7;// Tex7 addr 0x1abdd800 res 160x90x1 dim 1 tm: 4 format 041a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler7 ClampX/Y/Z: 2 2 2 border: 0
+// uf_remappedPS[5] was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(2, 1, 1) uniform sampler2D textureUnitPS2;
+TEXTURE_LAYOUT(3, 1, 2) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(4, 1, 3) uniform sampler2D textureUnitPS4;
+TEXTURE_LAYOUT(5, 1, 4) uniform sampler2D textureUnitPS5;
+TEXTURE_LAYOUT(6, 1, 5) uniform sampler2D textureUnitPS6;
+TEXTURE_LAYOUT(7, 1, 6) uniform sampler2D textureUnitPS7;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
 //uniform vec2 uf_fragCoordScale;

--- a/Enhancements/HyruleWarriors_Contrasty/rules.txt
+++ b/Enhancements/HyruleWarriors_Contrasty/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = Contrasty
 path = "Hyrule Warriors/Enhancements/Contrasty"
 description = This pack tweaks the colors and contrast to whatever preset you set it as. You can also make your own preset by editing the Default preset in the Contrasty folder from the game's graphic packs. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = Default

--- a/Enhancements/M&SRio2016_NoHUD/0535e0f9e37cf612_0000000000000000_vs.txt
+++ b/Enhancements/M&SRio2016_NoHUD/0535e0f9e37cf612_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 0535e0f9e37cf612
 #define enabled $enabled
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[8];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem3;
-layout(location = 2) in uvec4 attrDataSem4;
-layout(location = 3) in uvec4 attrDataSem8;
-layout(location = 4) in uvec4 attrDataSem9;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[8];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem9;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -119,7 +144,7 @@ R3f.z = (mul_nonIEEE(R125f.y,intBitsToFloat(uf_remappedVS[7].z)) + PV1f.y);
 R3f.w = (mul_nonIEEE(R125f.y,intBitsToFloat(uf_remappedVS[7].w)) + PV1f.x);
 // export
 #if (enabled == 0)
-gl_Position = vec4(R3f.x, R3f.y, R3f.z, R3f.w);
+SET_POSITION(vec4(R3f.x, R3f.y, R3f.z, R3f.w));
 #endif
 #if (enabled == 1)
 #endif

--- a/Enhancements/M&SRio2016_NoHUD/c7a21597bd595a25_0000000000000000_vs.txt
+++ b/Enhancements/M&SRio2016_NoHUD/c7a21597bd595a25_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader c7a21597bd595a25
 #define enabled $enabled
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[4];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem3;
-layout(location = 2) in uvec4 attrDataSem4;
-layout(location = 3) in uvec4 attrDataSem8;
-layout(location = 4) in uvec4 attrDataSem9;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[4];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem3;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem4;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem8;
+ATTR_LAYOUT(0, 4) in uvec4 attrDataSem9;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -97,7 +122,7 @@ R0f.y = (mul_nonIEEE(R3f.x,intBitsToFloat(uf_remappedVS[3].y)) + PV0f.y);
 R0f.w = (mul_nonIEEE(R3f.x,intBitsToFloat(uf_remappedVS[3].w)) + PV0f.x);
 // export
 #if (enabled == 0)
-gl_Position = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+SET_POSITION(vec4(R0f.x, R0f.y, R0f.z, R0f.w));
 #endif
 #if (enabled == 1)
 #endif

--- a/Enhancements/M&SRio2016_NoHUD/rules.txt
+++ b/Enhancements/M&SRio2016_NoHUD/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010190300,00050000101E5300,00050000101E5400
 name = No HUD
 path = "Mario & Sonic at the Rio 2016 Olympic Games/Enhancements/No HUD"
 description = Removes the HUD of the game. Made by Slashiee.
-version = 3
+version = 4
 
 [Preset]
 name = Disabled (Default)

--- a/Enhancements/NewSuperMarioBrosU_FancyFX/03285368cf940e37_0000000000000079_ps.txt
+++ b/Enhancements/NewSuperMarioBrosU_FancyFX/03285368cf940e37_0000000000000079_ps.txt
@@ -1,6 +1,23 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 03285368cf940e37 //box bg
 
 //float dither = $dither ;
@@ -10,10 +27,17 @@ const int sampleScale = 2;
 //float lightBloom = 0.95; 
 
 
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem3;
 layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 
 // FabriceNeyret2 CC, single shader gaussian by intermediate MIPmap level. www.shadertoy.com/view/ltScRG
 const int samples = 8 * sampleScale, //8 or 4 balances xy position

--- a/Enhancements/NewSuperMarioBrosU_FancyFX/rules.txt
+++ b/Enhancements/NewSuperMarioBrosU_FancyFX/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010101D00,0005000010101E00,000500001014B700,000500001014B800,0
 name = Resolution
 path = "New Super Mario Bros. U/Enhancements/Fancy FX" #and luigi
 description = Pretty blur, de-band sky, re-align cinematic etc, maintained on Nvidia. 
-version = 3
+version = 4
 
 
 [Preset]

--- a/Enhancements/NinjaGaiden3_Contrasty/a5e9d150276a805c_0000000000001e4a_ps.txt
+++ b/Enhancements/NinjaGaiden3_Contrasty/a5e9d150276a805c_0000000000001e4a_ps.txt
@@ -1,10 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader a5e9d150276a805c
 //light
 
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[2];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
 uniform vec2 uf_fragCoordScale;
+#endif
 
 const float hazeFactor = 0.1;
 
@@ -93,10 +119,10 @@ vec3 contrasty(vec3 colour){
 	return fColour;
 }
 
-uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4c24000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x3a86a000 res 160x90x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 2) uniform sampler3D textureUnitPS2;// Tex2 addr 0x3b2aa000 res 24x24x24 dim 2 tm: 1 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x18) Sampler2 ClampX/Y/Z: 2 2 2 border: 0
+// uf_remappedPS[2] was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler3D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
 

--- a/Enhancements/NinjaGaiden3_Contrasty/rules.txt
+++ b/Enhancements/NinjaGaiden3_Contrasty/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010110900,0005000010110A00,0005000010110B00
 name = Contrasty
 path = "Ninja Gaiden 3: Razors Edge/Enhancements/Contrasty"
 description = This pack tweaks the colors and contrast to whatever preset you set it as. You can also make your own preset by editing the Default preset in the Contrasty folder from the game's graphic packs. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = Default

--- a/Enhancements/SuperSmashBros_Contrasty/9f6adb9a651f84b9_0000000000000079_ps.txt
+++ b/Enhancements/SuperSmashBros_Contrasty/9f6adb9a651f84b9_0000000000000079_ps.txt
@@ -1,9 +1,35 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 9f6adb9a651f84b9 //cty
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[3];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
 uniform vec2 uf_fragCoordScale;
+#endif
 
 const float hazeFactor = $hazeFactor;
 
@@ -94,8 +120,8 @@ vec3 contrasty(vec3 colour){
 
 
 
-uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4ff4000 res 1920x1080x1 dim 1 tm: 4 format 0219 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+// uf_remappedPS[3] was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem130;
 layout(location = 0) out vec4 passPixelColor0;
 //uniform vec2 uf_fragCoordScale;

--- a/Enhancements/SuperSmashBros_Contrasty/rules.txt
+++ b/Enhancements/SuperSmashBros_Contrasty/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010110E00,0005000010145000,0005000010144F00
 name = Contrasty
 path = "Super Smash Bros. for Wii U/Enhancements/Contrasty"
 description = This pack tweaks the colors and contrast to whatever preset you set it as. You can also make your own preset by editing the Default preset in the Contrasty folder from the game's graphic packs. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = Default

--- a/Enhancements/SuperSmashBros_Shadows/7613a0515b67d8b4_0000000000000000_vs.txt
+++ b/Enhancements/SuperSmashBros_Shadows/7613a0515b67d8b4_0000000000000000_vs.txt
@@ -1,13 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 7613a0515b67d8b4
 const float shadowRes = $shadowRes;
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem2;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem2;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -69,7 +94,7 @@ PS1f = R3f.y;
 // 2
 R3f.z = R2f.x + R127f.w;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem130 = vec4(R0f.x, R0f.y, R0f.z, R0f.y);
 // export

--- a/Enhancements/SuperSmashBros_Shadows/rules.txt
+++ b/Enhancements/SuperSmashBros_Shadows/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010110E00,0005000010145000,0005000010144F00
 name = Shadow Resolution
 path = "Super Smash Bros. for Wii U/Graphics/Shadow Resolution"
 description = Note: Increasing shadow resolution is known to increase VRAM usage directly. Lowering this increases performance but makes shadows blockier. Medium is the original resolution.
-version = 3
+version = 4
 
 [Preset]
 name = Medium (100%, Default)

--- a/Enhancements/TokyoMirage_!AARemoval/04d0827b9471eb22_0000000000000000_vs.txt
+++ b/Enhancements/TokyoMirage_!AARemoval/04d0827b9471eb22_0000000000000000_vs.txt
@@ -1,13 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 04d0827b9471eb22
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -69,7 +94,7 @@ R0f.y = R2f.y + -(R127f.z);
 R0f.z = PV0f.y;
 R0f.w = PV0f.x;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem137 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Enhancements/TokyoMirage_!AARemoval/rules.txt
+++ b/Enhancements/TokyoMirage_!AARemoval/rules.txt
@@ -3,4 +3,4 @@ titleIds = 00050000101ED700,00050000101ED800,0005000010131D00
 name = AA Removal
 path = "Tokyo Mirage Sessions FE/Enhancements/AA Removal"
 description = Removes AA, no performance gain. Used for clean look or injecting external AA. Made by getdls.
-version = 3
+version = 4

--- a/Enhancements/TokyoMirage_!VideoPanNScan/dda6656146476243_0000000000000000_vs.txt
+++ b/Enhancements/TokyoMirage_!VideoPanNScan/dda6656146476243_0000000000000000_vs.txt
@@ -1,13 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader dda6656146476243
 //Video aspect
 const float UI = $UIAspectX;
 const float UIY = $UIAspectY;
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[5];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem8;
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -86,7 +110,7 @@ R0f.w = tempf.x;
 R1f.xyz = vec3(intBitsToFloat(uf_remappedVS[4].x),intBitsToFloat(uf_remappedVS[4].y),intBitsToFloat(uf_remappedVS[4].z));
 R1f.w = intBitsToFloat(uf_remappedVS[4].w);
 // export
-gl_Position = vec4(R0f.x*UI, R0f.y*UIY, R0f.z, R0f.w);
+SET_POSITION(vec4(R0f.x*UI, R0f.y*UIY, R0f.z, R0f.w));
 // export
 passParameterSem131 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
 // export

--- a/Enhancements/TokyoMirage_!VideoPanNScan/rules.txt
+++ b/Enhancements/TokyoMirage_!VideoPanNScan/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101ED700,00050000101ED800,0005000010131D00
 name = Video pan n scan
 path = "Tokyo Mirage Sessions FE/Graphics/Video pan n scan"
 description = 21:9 Video, cuts of sides instead of pillar-boxing. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = 21:9 Pan n scan (Cut top, bottom)

--- a/Enhancements/TokyoMirage_AdjustBlur/4d96f8f88575bcab_00000000000003c9_ps.txt
+++ b/Enhancements/TokyoMirage_AdjustBlur/4d96f8f88575bcab_00000000000003c9_ps.txt
@@ -1,16 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 4d96f8f88575bcab -- Used to blur out the main frame in various cutscenes
 
 float blur = $Blur;
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4fa8000 res 1280x720x1 dim 1 tm: 4 format 080e compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0xf4c24000 res 640x360x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 1) uniform sampler2D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem136;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/TokyoMirage_AdjustBlur/rules.txt
+++ b/Enhancements/TokyoMirage_AdjustBlur/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101ED700,00050000101ED800,0005000010131D00
 name = Adjust Cutscene Blur
 path = "Tokyo Mirage Sessions FE/Graphics/Adjust Cutscene Blur"
 description = Changes the in-game cut-scenes blur.  Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = 100% Blur (Original)

--- a/Enhancements/TokyoMirage_Contrasty/a7f4801a8d29e333_0000000000000079_ps.txt
+++ b/Enhancements/TokyoMirage_Contrasty/a7f4801a8d29e333_0000000000000079_ps.txt
@@ -1,9 +1,35 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader a7f4801a8d29e333 
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[3];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
 uniform vec2 uf_fragCoordScale;
+#endif
 
 const float hazeFactor = 0.1;
 
@@ -93,8 +119,8 @@ vec3 contrasty(vec3 colour){
 }
 
 const float resScale = 3.0;  //AA in PS 
-uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf470a000 res 1280x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+// uf_remappedPS[3] was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem136;
 layout(location = 1) in vec4 passParameterSem137;
 layout(location = 0) out vec4 passPixelColor0;

--- a/Enhancements/TokyoMirage_Contrasty/rules.txt
+++ b/Enhancements/TokyoMirage_Contrasty/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101ED700,00050000101ED800,0005000010131D00
 name = Contrasty
 path = "Tokyo Mirage Sessions FE/Enhancements/Contrasty"
 description = This pack tweaks the colors and contrast to whatever preset you set it as. You can also make your own preset by editing the Default preset in the Contrasty folder from the game's graphic packs. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = Default

--- a/Enhancements/TwilightPrincessHD_Contrasty/49865bd2e62efda1_0000000000000079_ps.txt
+++ b/Enhancements/TwilightPrincessHD_Contrasty/49865bd2e62efda1_0000000000000079_ps.txt
@@ -1,15 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 49865bd2e62efda1
 //dark world bloom
 
 const float bloom = $bloom;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf597f000 res 480x270x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/TwilightPrincessHD_Contrasty/5f422bf63e25be7f_0000000000000079_ps.txt
+++ b/Enhancements/TwilightPrincessHD_Contrasty/5f422bf63e25be7f_0000000000000079_ps.txt
@@ -1,15 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 5f422bf63e25be7f // Bleach pass cutscene
 
 const float bleach = $bleach;
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x24dfb000 res 960x540x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/TwilightPrincessHD_Contrasty/95a5a89d62998e0d_0000000000000079_ps.txt
+++ b/Enhancements/TwilightPrincessHD_Contrasty/95a5a89d62998e0d_0000000000000079_ps.txt
@@ -1,15 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 95a5a89d62998e0d
 
 // blur
 const float bloom = $bloom;
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf59ff000 res 480x270x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(location = 0) out vec4 passPixelColor0;
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
 uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+layout(location = 0) out vec4 passPixelColor0;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )
@@ -41,7 +67,7 @@ ivec4 ARi = ivec4(0);
 bool predResult = true;
 vec3 cubeMapSTM;
 int cubeMapFaceId;
-R0f = vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw);
+R0f = GET_FRAGCOORD();
 scaler =  uf_fragCoordScale.x;
 // 0
 R7f.x = R0f.x * intBitsToFloat(0x3b088889);

--- a/Enhancements/TwilightPrincessHD_Contrasty/c14019840473ff86_00000000000003c9_ps.txt
+++ b/Enhancements/TwilightPrincessHD_Contrasty/c14019840473ff86_00000000000003c9_ps.txt
@@ -1,8 +1,32 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader c14019840473ff86 //aa
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 
 const float hazeFactor = 0.1;
 
@@ -92,8 +116,8 @@ vec3 contrasty(vec3 colour){
 }
 
 
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4001000 res 1920x1080x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf5187000 res 1920x1080x1 dim 1 tm: 4 format 0011 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
 

--- a/Enhancements/TwilightPrincessHD_Contrasty/rules.txt
+++ b/Enhancements/TwilightPrincessHD_Contrasty/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001019C800,000500001019E600,000500001019E500
 name = Contrasty
 path = "The Legend of Zelda: Twilight Princess HD/Enhancements/Contrasty"
 description = This pack tweaks the colors and contrast to whatever preset you set it as. You can also make your own preset by editing the Default preset in the Contrasty folder from the game's graphic packs. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = default

--- a/Enhancements/TwilightPrincessHD_FancyFX/e334517825fdd599_0000000000000079_ps.txt
+++ b/Enhancements/TwilightPrincessHD_FancyFX/e334517825fdd599_0000000000000079_ps.txt
@@ -1,6 +1,23 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader e334517825fdd599
 //basline dof  blur.. 
 
@@ -9,10 +26,17 @@ const int sampleScaling = $presetPass;
 
 #define EnableBlur $enableBlur 
 
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4001000 res 1920x1080x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 
 
 const int sampleScale = 2 + sampleScaling;

--- a/Enhancements/TwilightPrincessHD_FancyFX/rules.txt
+++ b/Enhancements/TwilightPrincessHD_FancyFX/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001019C800,000500001019E600,000500001019E500
 name = Resolution
 path = "The Legend of Zelda: Twilight Princess HD/Enhancements/Fancy FX"
 description = Pretty blur, shadow x2, de-band sky, maintained on Nvidia. Made by getdls.
-version = 3
+version = 4
 
 
 [Preset] # Gaussian blur w correct scaling

--- a/Enhancements/VCGBA_Undarken/79ba8affb269f61c_0000000000000079_ps.txt
+++ b/Enhancements/VCGBA_Undarken/79ba8affb269f61c_0000000000000079_ps.txt
@@ -1,11 +1,35 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 79ba8affb269f61c
 // Checked against output from mGBA (191/255 = Wii U is 74.90196078431373‬% darker)
 // verified on Fire Emblem and Minish Cap
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 1) in vec4 passParameterSem129;
 layout(location = 0) out vec4 passPixelColor0;

--- a/Enhancements/VCGBA_Undarken/rules.txt
+++ b/Enhancements/VCGBA_Undarken/rules.txt
@@ -3,4 +3,4 @@ titleIds = 5000010173E00,5000010174000,5000010174100,5000010176100,5000010176000
 name = Undarken
 path = Virtual Console/GBA/Enhancements/Undarken
 description = Undarkens the emulator output. Made by Zalnor.
-version = 3
+version = 4

--- a/Enhancements/VCN64_Undarken/1494f789ce9ac901_000000000000000f_ps.txt
+++ b/Enhancements/VCN64_Undarken/1494f789ce9ac901_000000000000000f_ps.txt
@@ -1,9 +1,35 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 1494f789ce9ac901
+#ifdef VULKAN
+layout(set = 1, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[1];
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform ivec4 uf_remappedPS[1];
 uniform vec2 uf_fragCoordScale;
+#endif
+// uf_fragCoordScale was moved to the ufBlock
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
 int clampFI32(int v)

--- a/Enhancements/VCN64_Undarken/rules.txt
+++ b/Enhancements/VCN64_Undarken/rules.txt
@@ -3,4 +3,4 @@ titleIds = 50000101FEA00,50000101FE900,5000010199200,5000010199100,5000010199300
 name = Undarken
 path = Virtual Console/N64/Enhancements/Undarken
 description = Undarkens the emulator output. Made by Zalnor.
-version = 3
+version = 4

--- a/Enhancements/VCNES_Undarken/d2a97b2fb99411a5_0000000000000079_ps.txt
+++ b/Enhancements/VCNES_Undarken/d2a97b2fb99411a5_0000000000000079_ps.txt
@@ -1,9 +1,33 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader d2a97b2fb99411a5
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
 int clampFI32(int v)

--- a/Enhancements/VCNES_Undarken/rules.txt
+++ b/Enhancements/VCNES_Undarken/rules.txt
@@ -3,4 +3,4 @@ titleIds = 500001012A100,500001012DF00,500001012DE00,500001012E000,500001012E100
 name = Undarken
 path = Virtual Console/NES/Enhancements/Undarken
 description = Undarkens the emulator output. Made by Zalnor.
-version = 3
+version = 4

--- a/Enhancements/WindWakerHD_Contrasty/04dcbf2655f94e03_00000000000007f9_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/04dcbf2655f94e03_00000000000007f9_ps.txt
@@ -1,18 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 04dcbf2655f94e03 //hoirzon cloud layer lighten up
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
 
 const float skyboxRed = float($skyboxRed);
 const float skyboxGreen = float($skyboxGreen); 
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
-layout(binding = 3) uniform sampler2D textureUnitPS3;// Tex3 addr 0x2702c000 res 1024x256x1 dim 1 tm: 4 format 0433 compSel: 0 1 2 3 mipView: 0x0 (num 0xb) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 0 2 0 border: 0
+TEXTURE_LAYOUT(3, 1, 0) uniform sampler2D textureUnitPS3;
 layout(location = 0) in vec4 passParameterSem6;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/53141a02b3f78921_00000000000000ff_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/53141a02b3f78921_00000000000000ff_ps.txt
@@ -1,5 +1,22 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 53141a02b3f78921
 //make gradient more white blue 
 const float skyboxRed = float($skyboxRed);
@@ -7,11 +24,20 @@ const float skyboxGreen = float($skyboxGreen);
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
+#ifdef VULKAN
+layout(set = 1, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
 layout(location = 0) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/8a763b05908ba4e8_00000000000000ff_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/8a763b05908ba4e8_00000000000000ff_ps.txt
@@ -1,5 +1,22 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 8a763b05908ba4e8
 //Third band horizon
 const float skyboxRed = float($skyboxRed);
@@ -7,13 +24,22 @@ const float skyboxGreen = float($skyboxGreen);
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
+#ifdef VULKAN
+layout(set = 1, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
 layout(location = 0) in vec4 passParameterSem1;
 layout(location = 1) in vec4 passParameterSem2;
 layout(location = 2) in vec4 passParameterSem4;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/90ed656e9c17616b_00000000000000ff_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/90ed656e9c17616b_00000000000000ff_ps.txt
@@ -1,5 +1,22 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 90ed656e9c17616b
 //make second gradient more white blue 
 const float skyboxRed = float($skyboxRed);
@@ -7,11 +24,20 @@ const float skyboxGreen = float($skyboxGreen);
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
+#ifdef VULKAN
+layout(set = 1, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
 layout(location = 0) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/92d5cf316124c301_00000000007fd249_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/92d5cf316124c301_00000000007fd249_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 92d5cf316124c301
 //beach cooking
+#ifdef VULKAN
+layout(set = 1, binding = 5) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[7];
-layout(binding = 0) uniform sampler2DArray textureUnitPS0;// Tex0 addr 0x22754000 res 4x4x1 dim 5 tm: 2 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4200000 res 960x540x1 dim 1 tm: 4 format 0806 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x25304000 res 4096x4096x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 5 mipView: 0x0 (num 0xd) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 0 0 0 border: 1
-layout(binding = 3) uniform sampler2D textureUnitPS3;// Tex3 addr 0xf42ff800 res 960x540x1 dim 1 tm: 4 format 001a compSel: 1 2 3 0 mipView: 0x0 (num 0x2) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 4) uniform sampler2D textureUnitPS4;// Tex4 addr 0x26528000 res 512x2048x1 dim 1 tm: 4 format 0431 compSel: 0 1 2 3 mipView: 0x0 (num 0xc) sliceView: 0x0 (num 0x1) Sampler4 ClampX/Y/Z: 0 0 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[7];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2DArray textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
+TEXTURE_LAYOUT(3, 1, 3) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(4, 1, 4) uniform sampler2D textureUnitPS4;
 layout(location = 0) in vec4 passParameterSem1;
 layout(location = 1) in vec4 passParameterSem2;
 layout(location = 2) in vec4 passParameterSem4;
@@ -18,7 +44,7 @@ layout(location = 5) in vec4 passParameterSem7;
 layout(location = 6) in vec4 passParameterSem8;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/960d3ef6662043c7_0000000000000079_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/960d3ef6662043c7_0000000000000079_ps.txt
@@ -1,15 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 960d3ef6662043c7//bloom blend
 const float skyboxRed = float($skyboxRed);
 const float skyboxGreen = float($skyboxGreen); 
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4000800 res 480x270x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x4) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/b77c717f243c0b08_00000000007f9249_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/b77c717f243c0b08_00000000007f9249_ps.txt
@@ -1,18 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader b77c717f243c0b08
+#ifdef VULKAN
+layout(set = 1, binding = 5) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[9];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[9];
+uniform vec2 uf_fragCoordScale;
+#endif
 const float skyboxRed = float($skyboxRed);
 const float skyboxGreen = float($skyboxGreen); 
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
 
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x25672000 res 4096x4096x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 5 mipView: 0x0 (num 0xd) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 0 0 0 border: 1
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0xf42ff800 res 960x540x1 dim 1 tm: 4 format 001a compSel: 1 2 3 0 mipView: 0x0 (num 0x2) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 3) uniform sampler2D textureUnitPS3;// Tex3 addr 0x2df1f000 res 1024x1024x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 0 mipView: 0x0 (num 0xb) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 0 0 2 border: 1
-layout(binding = 4) uniform sampler2D textureUnitPS4;// Tex4 addr 0x2dfcb000 res 256x256x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 0 mipView: 0x0 (num 0x9) sliceView: 0x0 (num 0x1) Sampler4 ClampX/Y/Z: 0 0 2 border: 1
-layout(binding = 5) uniform sampler2D textureUnitPS5;// Tex5 addr 0x2df1f000 res 1024x1024x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 0 mipView: 0x0 (num 0xb) sliceView: 0x0 (num 0x1) Sampler5 ClampX/Y/Z: 0 0 2 border: 1
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 1) uniform sampler2D textureUnitPS2;
+TEXTURE_LAYOUT(3, 1, 2) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(4, 1, 3) uniform sampler2D textureUnitPS4;
+TEXTURE_LAYOUT(5, 1, 4) uniform sampler2D textureUnitPS5;
 layout(location = 0) in vec4 passParameterSem2;
 layout(location = 1) in vec4 passParameterSem4;
 layout(location = 2) in vec4 passParameterSem5;
@@ -22,7 +48,7 @@ layout(location = 5) in vec4 passParameterSem8;
 layout(location = 6) in vec4 passParameterSem9;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/c2cae30e906be2d5_0000000000001e49_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/c2cae30e906be2d5_0000000000001e49_ps.txt
@@ -1,15 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader c2cae30e906be2d5
 //Ao scale 
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[8];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4200000 res 960x540x1 dim 1 tm: 4 format 0806 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4200000 res 960x540x1 dim 1 tm: 4 format 0806 compSel: 0 4 4 5 mipView: 0x0 (num 0x2) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x3b5d5800 res 4x4x1 dim 1 tm: 2 format 0007 compSel: 0 1 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 0 0 0 border: 1
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[8];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/e1ea1127489fd281_0000000000003fc9_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/e1ea1127489fd281_0000000000003fc9_ps.txt
@@ -1,21 +1,47 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader e1ea1127489fd281 // horizon
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[5];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[5];
+uniform vec2 uf_fragCoordScale;
+#endif
 const float skyboxRed = float($skyboxRed);
 const float skyboxGreen = float($skyboxGreen); 
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x25672000 res 4096x4096x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 5 mipView: 0x0 (num 0xd) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 0 0 0 border: 1
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0xf42ff800 res 960x540x1 dim 1 tm: 4 format 001a compSel: 1 2 3 0 mipView: 0x0 (num 0x2) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 2 2 2 border: 1
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 1) uniform sampler2D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem2;
 layout(location = 1) in vec4 passParameterSem4;
 layout(location = 2) in vec4 passParameterSem5;
 layout(location = 3) in vec4 passParameterSem6;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/ef821134ed8dd294_0000000000003fc9_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/ef821134ed8dd294_0000000000003fc9_ps.txt
@@ -1,22 +1,48 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader ef821134ed8dd294 // horizon 2 missing shader
 const float skyboxRed = float($skyboxRed);
 const float skyboxGreen = float($skyboxGreen); 
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[5];
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x25304000 res 4096x4096x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 5 mipView: 0x0 (num 0xd) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 0 0 0 border: 1
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0xf42ff800 res 960x540x1 dim 1 tm: 4 format 001a compSel: 1 2 3 0 mipView: 0x0 (num 0x2) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 2 2 2 border: 1
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[5];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 1) uniform sampler2D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem2;
 layout(location = 1) in vec4 passParameterSem4;
 layout(location = 2) in vec4 passParameterSem5;
 layout(location = 3) in vec4 passParameterSem6;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/f1a49f43d95bec30_00000000000000ff_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/f1a49f43d95bec30_00000000000000ff_ps.txt
@@ -1,15 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader f1a49f43d95bec30 //skybox
 const float skyboxRed = float($skyboxRed);
 const float skyboxGreen = float($skyboxGreen); 
 const float skyboxBlue = float($skyboxBlue);
 const float skyboxMix = float($skyboxMix);
 
+#ifdef VULKAN
+layout(set = 1, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_Contrasty/ff71dcd2ad4defdc_00000000000003c9_ps.txt
+++ b/Enhancements/WindWakerHD_Contrasty/ff71dcd2ad4defdc_00000000000003c9_ps.txt
@@ -1,9 +1,35 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader ff71dcd2ad4defdc
 //AA ps
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[4];
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[4];
 uniform vec2 uf_fragCoordScale;
+#endif
 
 const float hazeFactor = 0.1;
 
@@ -94,9 +120,9 @@ vec3 contrasty(vec3 colour){
 
 
 const float resScale = 2.0;
-uniform ivec4 uf_remappedPS[4];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf5807800 res 1920x1080x1 dim 1 tm: 4 format 0019 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4000800 res 1920x1080x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 1
+// uf_remappedPS[4] was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem2;
 layout(location = 0) out vec4 passPixelColor0;
 //uniform vec2 uf_fragCoordScale;

--- a/Enhancements/WindWakerHD_Contrasty/rules.txt
+++ b/Enhancements/WindWakerHD_Contrasty/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010143400,0005000010143600,0005000010143500
 name = Contrasty
 path = "The Legend of Zelda: The Wind Waker HD/Enhancements/Contrasty v1.1"
 description = This pack tweaks the colors and contrast to whatever preset you set it as. You can also make your own preset by editing the Default preset in the Contrasty folder from the game's graphic packs. Enabling will ignore your other AA settings. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = Default

--- a/Enhancements/WindWakerHD_LODBias/rules.txt
+++ b/Enhancements/WindWakerHD_LODBias/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010143400,0005000010143600,0005000010143500
 name = Negative texture LOD bias
 path = "The Legend of Zelda: The Wind Waker HD/Enhancements/Negative Texture LOD" 
 description = Texture LOD override, possible shimmer but sharper textures.
-version = 3
+version = 4
 
 [Preset]
 name = LOD Default

--- a/Enhancements/WindWakerHD_NoSSAO/c2cae30e906be2d5_0000000000001e49_ps.txt
+++ b/Enhancements/WindWakerHD_NoSSAO/c2cae30e906be2d5_0000000000001e49_ps.txt
@@ -1,15 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader c2cae30e906be2d5
 // Wind Waker - NoSSAO
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[8];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4200000 res 960x540x1 dim 1 tm: 4 format 0806 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4200000 res 960x540x1 dim 1 tm: 4 format 0806 compSel: 0 4 4 5 mipView: 0x0 (num 0x2) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x3b943800 res 4x4x1 dim 1 tm: 2 format 0007 compSel: 0 1 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 0 0 0 border: 1
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[8];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/WindWakerHD_NoSSAO/rules.txt
+++ b/Enhancements/WindWakerHD_NoSSAO/rules.txt
@@ -3,4 +3,4 @@ titleIds = 0005000010143400,0005000010143600,0005000010143500
 name = No SSAO
 path = "The Legend of Zelda: The Wind Waker HD/Enhancements/No SSAO" 
 description = Removes the SSAO of the game, which are these little blurred shadows around Link when you're standing under a tree, for example.
-version = 3
+version = 4

--- a/Enhancements/ZombiU_ChromaticAberration/949069c3567f349d_0000000000000079_ps.txt
+++ b/Enhancements/ZombiU_ChromaticAberration/949069c3567f349d_0000000000000079_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 949069c3567f349d
 // color grading / chromatic aberration
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4a8e000 res 1280x720x1 dim 1 tm: 4 format 0019 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem130;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 	if( v == 0x7FFFFFFF )

--- a/Enhancements/ZombiU_ChromaticAberration/rules.txt
+++ b/Enhancements/ZombiU_ChromaticAberration/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001010DD00,000500001010EF00,0005000010112300,000500001011A700,0
 name = Chromatic Aberration
 path = "ZombiU/Enhancements/Chromatic Aberration"
 description = Changes the intensity of horizontal chromatic aberration. (the red/green/blue edges)
-version = 3
+version = 4
 
 [Preset]
 name = CA Default

--- a/Enhancements/ZombiU_LessLensDirt/ee4bd70a942d3687_00000000000003c9_ps.txt
+++ b/Enhancements/ZombiU_LessLensDirt/ee4bd70a942d3687_00000000000003c9_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader ee4bd70a942d3687
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x2f5f4000 res 256x256x1 dim 1 tm: 4 format 0031 compSel: 0 1 2 3 mipView: 0x1 (num 0x8) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 0 0 0 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x2a7f1000 res 1280x720x1 dim 1 tm: 4 format 0031 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 0 0 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem130;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Enhancements/ZombiU_LessLensDirt/rules.txt
+++ b/Enhancements/ZombiU_LessLensDirt/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001010DD00,000500001010EF00,0005000010112300,000500001011A700,0
 name = Lens Dirt Adjustment
 path = "ZombiU/Enhancements/Lens Dirt Adjustment"
 description = Changes the intensity of the lens dirt effect.
-version = 3
+version = 4
 
 [Preset]
 name = Lens Dirt Default

--- a/Resolutions/Bayonetta2_Resolution/00fed4f92a49e851_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta2_Resolution/00fed4f92a49e851_0000000000000079_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 00fed4f92a49e851
 //cut scen blur pass 2 a 
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x462bd800 res 320x180x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta2_Resolution/284b1bf9010d4e57_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta2_Resolution/284b1bf9010d4e57_0000000000000079_ps.txt
@@ -1,11 +1,35 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 284b1bf9010d4e57
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf489f800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 float scaleFactor = uf_fragCoordScale.x;
 int clampFI32(int v)
 {

--- a/Resolutions/Bayonetta2_Resolution/43a2239f07af804e_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta2_Resolution/43a2239f07af804e_0000000000000079_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 43a2239f07af804e
 //horizontal blur
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf53f9800 res 320x176x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta2_Resolution/73ac09c3fff4b657_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta2_Resolution/73ac09c3fff4b657_0000000000000079_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 73ac09c3fff4b657
 //cut scene vert blur //redundant?
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x462fa000 res 320x180x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta2_Resolution/75387173950c1793_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta2_Resolution/75387173950c1793_0000000000000079_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 75387173950c1793
 //vert blur
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf536f000 res 320x176x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta2_Resolution/78a2659662685d55_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta2_Resolution/78a2659662685d55_0000000000000079_ps.txt
@@ -1,12 +1,36 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 78a2659662685d55
 //specular highlight
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4c24000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 float scaleFactor = uf_fragCoordScale.x;
 int clampFI32(int v)
 {

--- a/Resolutions/Bayonetta2_Resolution/8a0efcdc3f556942_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta2_Resolution/8a0efcdc3f556942_0000000000000079_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 8a0efcdc3f556942 
 //halfres, pyarmid start
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf451b000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta2_Resolution/e5870717602e2f55_0000000000000000_vs.txt
+++ b/Resolutions/Bayonetta2_Resolution/e5870717602e2f55_0000000000000000_vs.txt
@@ -1,14 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader e5870717602e2f55 //layer blur
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[8];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
-layout(location = 2) in uvec4 attrDataSem16;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[8];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem16;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -152,7 +177,7 @@ PS1f = R3f.z;
 R2f.z = mul_nonIEEE(R1f.z, intBitsToFloat(uf_remappedVS[7].z));
 R2f.w = mul_nonIEEE(R1f.w, intBitsToFloat(uf_remappedVS[7].w));
 // export
-gl_Position = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
+SET_POSITION(vec4(R0f.x, R0f.y, R0f.z, R0f.w));
 // export
 // skipped export to semanticId 255
 // export

--- a/Resolutions/Bayonetta2_Resolution/rules.txt
+++ b/Resolutions/Bayonetta2_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010172600,0005000010172700,000500001011B900
 name = Resolution
 path = "Bayonetta 2/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Slashiee and getdls.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/Bayonetta_Resolution/117889891fd19c30_000000000000001e_ps.txt
+++ b/Resolutions/Bayonetta_Resolution/117889891fd19c30_000000000000001e_ps.txt
@@ -1,16 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 117889891fd19c30
 //menu
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
 uniform float uf_alphaTestRef;
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4000800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform float uf_alphaTestRef;
+uniform vec2 uf_fragCoordScale;
+#endif
+// uf_alphaTestRef was moved to the ufBlock
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem129;
 layout(location = 1) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta_Resolution/212e4514290f2693_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta_Resolution/212e4514290f2693_0000000000000079_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 212e4514290f2693
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4e48800 res 320x176x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta_Resolution/51f398ee2e3e18a6_0000000000000079_ps.txt
+++ b/Resolutions/Bayonetta_Resolution/51f398ee2e3e18a6_0000000000000079_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 51f398ee2e3e18a6
 //blur vert
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4e11800 res 320x176x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta_Resolution/6e828da50daedc79_00000000000003c9_ps.txt
+++ b/Resolutions/Bayonetta_Resolution/6e828da50daedc79_00000000000003c9_ps.txt
@@ -1,15 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 6e828da50daedc79
 // cut scene blur
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf5195800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 0 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4709800 res 1280x720x1 dim 1 tm: 4 format 080e compSel: 0 0 0 0 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta_Resolution/9d1d7119cc2a1bc5_00000000000003c9_ps.txt
+++ b/Resolutions/Bayonetta_Resolution/9d1d7119cc2a1bc5_00000000000003c9_ps.txt
@@ -1,15 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 9d1d7119cc2a1bc5
 //film simulation blur
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf5195800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 0 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4709800 res 1280x720x1 dim 1 tm: 4 format 080e compSel: 0 0 0 0 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta_Resolution/f015876e4c8e82f9_000000000000001e_ps.txt
+++ b/Resolutions/Bayonetta_Resolution/f015876e4c8e82f9_000000000000001e_ps.txt
@@ -1,16 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader f015876e4c8e82f9
 //menu 2d blur
 const float resScale = float($height)/float($gameHeight);
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[1];
 uniform float uf_alphaTestRef;
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf4000800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[1];
+uniform float uf_alphaTestRef;
+uniform vec2 uf_fragCoordScale;
+#endif
+// uf_alphaTestRef was moved to the ufBlock
+TEXTURE_LAYOUT(1, 1, 0) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem129;
 layout(location = 1) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/Bayonetta_Resolution/rules.txt
+++ b/Resolutions/Bayonetta_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001014DB00,0005000010157E00,0005000010157F00
 name = Resolution
 path = "Bayonetta/Graphics/Resolution"
 description = Changes the resolution of the game.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/DrLuigi_Resolution/9e9abde99f9510dc_000000000000001c_ps.txt
+++ b/Resolutions/DrLuigi_Resolution/9e9abde99f9510dc_000000000000001c_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 9e9abde99f9510dc
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform float uf_alphaTestRef;
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf489e000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform float uf_alphaTestRef;
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem129;
 layout(location = 1) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/DrLuigi_Resolution/rules.txt
+++ b/Resolutions/DrLuigi_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010150300,0005000010152A00,0005000010152B00
 name = Resolution
 path = "Dr. Luigi/Graphics/Resolution"
 description = Changes the resolution of the game. Anti-aliasing is disabled by default. Made by Slashiee.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/DucktalesRemastered_Resolution/294904d1771460cf_0000000000000079_ps.txt
+++ b/Resolutions/DucktalesRemastered_Resolution/294904d1771460cf_0000000000000079_ps.txt
@@ -1,14 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 294904d1771460cf
 // Used for: Blur
 const float resScale = (float($width)/float($gameWidth));
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[1];
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform ivec4 uf_remappedPS[1];
 uniform vec2 uf_fragCoordScale;
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf5b14800 res 480x270x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+#endif
+// uf_fragCoordScale was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
 int clampFI32(int v)

--- a/Resolutions/DucktalesRemastered_Resolution/8fdd009324e987ee_0000000000000079_ps.txt
+++ b/Resolutions/DucktalesRemastered_Resolution/8fdd009324e987ee_0000000000000079_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 8fdd009324e987ee
 // Used for: Blur
 const float resScale = (float($width)/float($gameWidth));
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[1];
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform ivec4 uf_remappedPS[1];
 uniform vec2 uf_fragCoordScale;
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf5b94000 res 480x270x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+#endif
+// uf_fragCoordScale was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem128;
 layout(location = 0) out vec4 passPixelColor0;
 int clampFI32(int v)

--- a/Resolutions/DucktalesRemastered_Resolution/rules.txt
+++ b/Resolutions/DucktalesRemastered_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010129000,0005000010129200
 name = Resolution
 path = "DuckTales: Remastered/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Crementif.
-version = 3
+version = 4
 
 [Preset]
 name = 1920x1080 (Default)

--- a/Resolutions/FistOfTheNorthStar_Resolution/945d9672d0114248_0000000000000000_vs.txt
+++ b/Resolutions/FistOfTheNorthStar_Resolution/945d9672d0114248_0000000000000000_vs.txt
@@ -1,15 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 945d9672d0114248
 // Used for: Second horizontal and vertical bloom blur pass
 float resXScale = float($width)/float($gameWidth);
 float resYScale = float($height)/float($gameHeight);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -280,7 +303,7 @@ Ri[3].xyz = ivec3(Ri[14].x,Ri[14].y,Ri[14].z);
 Ri[3].w = Ri[14].w;
 }
 // export
-gl_Position = vec4(intBitsToFloat(Ri[2].x), intBitsToFloat(Ri[2].y), intBitsToFloat(Ri[2].z), intBitsToFloat(Ri[2].w));
+SET_POSITION(vec4(intBitsToFloat(Ri[2].x), intBitsToFloat(Ri[2].y), intBitsToFloat(Ri[2].z), intBitsToFloat(Ri[2].w)));
 // export
 passParameterSem129 = vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w));
 // export

--- a/Resolutions/FistOfTheNorthStar_Resolution/b3609db7d1363f6a_0000000000000000_vs.txt
+++ b/Resolutions/FistOfTheNorthStar_Resolution/b3609db7d1363f6a_0000000000000000_vs.txt
@@ -1,15 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader b3609db7d1363f6a
 // Used for: Horizontal and vertical blur
 float resXScale = float($width)/float($gameWidth);
 float resYScale = float($height)/float($gameHeight);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -302,7 +325,7 @@ Ri[8].xyz = ivec3(Ri[28].x,Ri[28].y,Ri[28].z);
 Ri[8].w = Ri[28].w;
 }
 // export
-gl_Position = vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w));
+SET_POSITION(vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w)));
 // export
 passParameterSem128 = vec4(intBitsToFloat(Ri[1].x), intBitsToFloat(Ri[1].y), intBitsToFloat(Ri[1].z), intBitsToFloat(Ri[1].w));
 // export

--- a/Resolutions/FistOfTheNorthStar_Resolution/f9feadb214b483b7_0000000000000000_vs.txt
+++ b/Resolutions/FistOfTheNorthStar_Resolution/f9feadb214b483b7_0000000000000000_vs.txt
@@ -1,15 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader f9feadb214b483b7
 // Used for: First horizontal and vertical bloom blur pass
 float resXScale = float($width)/float($gameWidth);
 float resYScale = float($height)/float($gameHeight);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -301,7 +324,7 @@ Ri[6].xyz = ivec3(Ri[23].x,Ri[23].y,Ri[23].z);
 Ri[6].w = Ri[23].w;
 }
 // export
-gl_Position = vec4(intBitsToFloat(Ri[2].x), intBitsToFloat(Ri[2].y), intBitsToFloat(Ri[2].z), intBitsToFloat(Ri[2].w));
+SET_POSITION(vec4(intBitsToFloat(Ri[2].x), intBitsToFloat(Ri[2].y), intBitsToFloat(Ri[2].z), intBitsToFloat(Ri[2].w)));
 // export
 passParameterSem129 = vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w));
 // export

--- a/Resolutions/FistOfTheNorthStar_Resolution/rules.txt
+++ b/Resolutions/FistOfTheNorthStar_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001012B800,000500001012B900,0005000010116600
 name = Resolution
 path = "Fist of the North Star: Ken's Rage 2/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Crementif.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/HyruleWarriors_Resolution/492839ddc5f8f43e_0000000000000000_vs.txt
+++ b/Resolutions/HyruleWarriors_Resolution/492839ddc5f8f43e_0000000000000000_vs.txt
@@ -1,14 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 492839ddc5f8f43e //3rd level dof
 const float resXScale =  float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -259,7 +284,7 @@ Ri[2].xyz = ivec3(Ri[10].x,Ri[10].y,Ri[10].z);
 Ri[2].w = Ri[10].w;
 }
 // export
-gl_Position = vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w));
+SET_POSITION(vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w)));
 // export
 passParameterSem128 = vec4(intBitsToFloat(Ri[1].x), intBitsToFloat(Ri[1].y), intBitsToFloat(Ri[1].z), intBitsToFloat(Ri[1].w));
 // export

--- a/Resolutions/HyruleWarriors_Resolution/945d9672d0114248_0000000000000000_vs.txt
+++ b/Resolutions/HyruleWarriors_Resolution/945d9672d0114248_0000000000000000_vs.txt
@@ -1,14 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 945d9672d0114248
 const float resXScale =  float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -279,7 +304,7 @@ Ri[3].xyz = ivec3(Ri[14].x,Ri[14].y,Ri[14].z);
 Ri[3].w = Ri[14].w;
 }
 // export
-gl_Position = vec4(intBitsToFloat(Ri[2].x), intBitsToFloat(Ri[2].y), intBitsToFloat(Ri[2].z), intBitsToFloat(Ri[2].w));
+SET_POSITION(vec4(intBitsToFloat(Ri[2].x), intBitsToFloat(Ri[2].y), intBitsToFloat(Ri[2].z), intBitsToFloat(Ri[2].w)));
 // export
 passParameterSem129 = vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w));
 // export

--- a/Resolutions/HyruleWarriors_Resolution/b3609db7d1363f6a_0000000000000000_vs.txt
+++ b/Resolutions/HyruleWarriors_Resolution/b3609db7d1363f6a_0000000000000000_vs.txt
@@ -1,15 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader b3609db7d1363f6a
 //cutscene dof boxes
 const float resXScale =  (float($width)/float($gameWidth))*float($internalRes);
 const float resYScale = (float($height)/float($gameHeight))*float($internalRes); 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -302,7 +327,7 @@ Ri[8].xyz = ivec3(Ri[28].x,Ri[28].y,Ri[28].z);
 Ri[8].w = Ri[28].w;
 }
 // export
-gl_Position = vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w));
+SET_POSITION(vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w)));
 // export
 passParameterSem128 = vec4(intBitsToFloat(Ri[1].x), intBitsToFloat(Ri[1].y), intBitsToFloat(Ri[1].z), intBitsToFloat(Ri[1].w));
 // export

--- a/Resolutions/HyruleWarriors_Resolution/f9feadb214b483b7_0000000000000000_vs.txt
+++ b/Resolutions/HyruleWarriors_Resolution/f9feadb214b483b7_0000000000000000_vs.txt
@@ -1,14 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader f9feadb214b483b7
 const float resXScale =  float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -300,7 +325,7 @@ Ri[6].xyz = ivec3(Ri[23].x,Ri[23].y,Ri[23].z);
 Ri[6].w = Ri[23].w;
 }
 // export
-gl_Position = vec4(intBitsToFloat(Ri[2].x), intBitsToFloat(Ri[2].y), intBitsToFloat(Ri[2].z), intBitsToFloat(Ri[2].w));
+SET_POSITION(vec4(intBitsToFloat(Ri[2].x), intBitsToFloat(Ri[2].y), intBitsToFloat(Ri[2].z), intBitsToFloat(Ri[2].w)));
 // export
 passParameterSem129 = vec4(intBitsToFloat(Ri[0].x), intBitsToFloat(Ri[0].y), intBitsToFloat(Ri[0].z), intBitsToFloat(Ri[0].w));
 // export

--- a/Resolutions/HyruleWarriors_Resolution/rules.txt
+++ b/Resolutions/HyruleWarriors_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = Resolution
 path = "Hyrule Warriors/Graphics/Resolution"
 description = Changes the resolution of the game. Made by getdls.
-version = 3
+version = 4
 
 #Resolutions						|Aspect ratio
 #2560×1080, 5120×2160, 8192×3456	|64:27 (2.370)

--- a/Resolutions/KirbyRainbow_Resolution/2258c1c082f929aa_0000000000000000_vs.txt
+++ b/Resolutions/KirbyRainbow_Resolution/2258c1c082f929aa_0000000000000000_vs.txt
@@ -1,15 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 2258c1c082f929aa
 // Used for: Stage Background Blur, Clay Texture Blur
 const float resXScale = float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterVS[256];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_uniformRegisterVS[256];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -74,7 +99,7 @@ R2i.y = floatBitsToInt(intBitsToFloat(uf_uniformRegisterVS[5].y)/resYScale + int
 R3i.x = floatBitsToInt(intBitsToFloat(uf_uniformRegisterVS[6].x)/resXScale + intBitsToFloat(uf_uniformRegisterVS[ARi.x+7].x));
 R3i.y = floatBitsToInt(intBitsToFloat(uf_uniformRegisterVS[6].y)/resYScale + intBitsToFloat(uf_uniformRegisterVS[ARi.x+7].y));
 // export
-gl_Position = vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w));
+SET_POSITION(vec4(intBitsToFloat(R1i.x), intBitsToFloat(R1i.y), intBitsToFloat(R1i.z), intBitsToFloat(R1i.w)));
 // export
 passParameterSem0 = vec4(intBitsToFloat(R0i.x), intBitsToFloat(R0i.y), intBitsToFloat(R0i.z), intBitsToFloat(R0i.z));
 // export

--- a/Resolutions/KirbyRainbow_Resolution/rules.txt
+++ b/Resolutions/KirbyRainbow_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101ABC00,00050000101B5100
 name = Resolution
 path = "Kirby and the Rainbow Curse & Paintbrush/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Crementif.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/MarioParty10_Resolution/5ce4bcf08c2aa688_0000000000000000_vs.txt
+++ b/Resolutions/MarioParty10_Resolution/5ce4bcf08c2aa688_0000000000000000_vs.txt
@@ -1,17 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 5ce4bcf08c2aa688
 // Used for: Bloom
 const float resXScale = float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight);
 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[6];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[6];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -243,7 +268,7 @@ PV1i.x = tempResulti;
 R4i.x = ((ARi.x==0)?R9i.x:(ARi.x==24)?R33i.x:(ARi.x==25)?R34i.x:(ARi.x==26)?R35i.x:(ARi.x==27)?R36i.x:(ARi.x==118)?R127i.x:0);
 R4i.y = ((ARi.x==0)?R9i.y:(ARi.x==24)?R33i.y:(ARi.x==25)?R34i.y:(ARi.x==26)?R35i.y:(ARi.x==27)?R36i.y:(ARi.x==118)?R127i.y:0);
 // export
-gl_Position = vec4(intBitsToFloat(R5i.x), intBitsToFloat(R5i.y), intBitsToFloat(R5i.z), intBitsToFloat(R5i.w));
+SET_POSITION(vec4(intBitsToFloat(R5i.x), intBitsToFloat(R5i.y), intBitsToFloat(R5i.z), intBitsToFloat(R5i.w)));
 // 0
 R5i.x = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.z)/resXScale,intBitsToFloat(uf_remappedVS[4].x)) + intBitsToFloat(R4i.x)));
 R5i.y = floatBitsToInt((mul_nonIEEE(intBitsToFloat(R0i.w)/resYScale,intBitsToFloat(uf_remappedVS[4].y)) + intBitsToFloat(R4i.y)));

--- a/Resolutions/MarioParty10_Resolution/rules.txt
+++ b/Resolutions/MarioParty10_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010162D00,0005000010162E00,0005000E10161F00
 name = Resolution
 path = "Mario Party 10/Graphics/Resolution"
 description = Changes the resolution of the game. Note: Missing videos in minigame screen is currently a Cemu/Cemuhook issue.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/NewSuperMarioBrosU_Resolution/50e29e8929cea348_00000000000003c9_ps.txt
+++ b/Resolutions/NewSuperMarioBrosU_Resolution/50e29e8929cea348_00000000000003c9_ps.txt
@@ -1,17 +1,43 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 50e29e8929cea348
 // Used for: Scaling Anti-Aliasing solution of game
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[3];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4240800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0xf45c5000 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 1
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[3];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
 
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 float resScale = (1.0 / uf_fragCoordScale.x); 
 
 int clampFI32(int v)

--- a/Resolutions/NewSuperMarioBrosU_Resolution/70b82af4d17024d2_0000000000000000_vs.txt
+++ b/Resolutions/NewSuperMarioBrosU_Resolution/70b82af4d17024d2_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 70b82af4d17024d2
 //AA fix
 
 float resScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -70,7 +95,7 @@ R2f.z = PS0f;
 // 2
 R2f.w = PV1f.x;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem1 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
 // 0

--- a/Resolutions/NewSuperMarioBrosU_Resolution/8d638f35cebd14dc_00000000000007f9_ps.txt
+++ b/Resolutions/NewSuperMarioBrosU_Resolution/8d638f35cebd14dc_00000000000007f9_ps.txt
@@ -1,25 +1,49 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 8d638f35cebd14dc
 //banding fix
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x48ab0000 res 8x256x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x9) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 0 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 2) in vec4 passParameterSem2;
 layout(location = 3) in vec4 passParameterSem3;
 layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
-highp float lineRand(vec2 co)
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/NewSuperMarioBrosU_Resolution/ec4a85d51e778437_0000000000000000_vs.txt
+++ b/Resolutions/NewSuperMarioBrosU_Resolution/ec4a85d51e778437_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader ec4a85d51e778437
 //box blur fix
 
 float resScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -73,7 +98,7 @@ PS1f = R2f.x;
 // 2
 R2f.w = PV1f.x;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem3 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
 // 0

--- a/Resolutions/NewSuperMarioBrosU_Resolution/rules.txt
+++ b/Resolutions/NewSuperMarioBrosU_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010101D00,0005000010101E00,000500001014B700,000500001014B800,0
 name = Resolution
 path = "New Super Mario Bros. U/Graphics/Resolution" #and luigi
 description = Changes the resolution of the game. Made by getdls.
-version = 3
+version = 4
 
 //compatible resolutions
 [Preset]

--- a/Resolutions/NinjaGaiden3_Resolution/7a641a67c4009f7f_0000000000000000_vs.txt
+++ b/Resolutions/NinjaGaiden3_Resolution/7a641a67c4009f7f_0000000000000000_vs.txt
@@ -1,17 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 7a641a67c4009f7f //Blur
 
 
 const float resXScale =  float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[8];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[8];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -129,7 +154,7 @@ R8f.w = R125f.z;
 R10f.x = R2f.x + intBitsToFloat(uf_remappedVS[6].x)/resXScale;
 PS0f = R10f.x;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem128 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/NinjaGaiden3_Resolution/fd6c2e800481a180_0000000000000000_vs.txt
+++ b/Resolutions/NinjaGaiden3_Resolution/fd6c2e800481a180_0000000000000000_vs.txt
@@ -1,17 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader fd6c2e800481a180 //Cinematic bloom
 
 const float resXScale =  float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[8];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[8];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -133,7 +158,7 @@ R8f.w = R125f.z;
 R10f.x = R2f.x + intBitsToFloat(uf_remappedVS[6].x)/resXScale;
 PS0f = R10f.x;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem128 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/NinjaGaiden3_Resolution/rules.txt
+++ b/Resolutions/NinjaGaiden3_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010110900,0005000010110A00,0005000010110B00
 name = Resolution
 path = "Ninja Gaiden 3: Razors Edge/Graphics/Resolution"
 description = Changes the resolution of the game. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/Pikmin3_Resolution/263a134082e695a0_0000000000000000_vs.txt
+++ b/Resolutions/Pikmin3_Resolution/263a134082e695a0_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 263a134082e695a0
 // Used for: Scaling Horizontal Bloom Pass
 const float resXScale = float($width)/float($gameWidth);
 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -93,7 +118,7 @@ PS1f = R2f.z;
 // 4
 R2f.x = R3f.x;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem1 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/Pikmin3_Resolution/4313ad4062c8d8f6_0000000000000000_vs.txt
+++ b/Resolutions/Pikmin3_Resolution/4313ad4062c8d8f6_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 4313ad4062c8d8f6
 // Used for: Scaling Vertical Bloom Pass
 const float resYScale = float($height)/float($gameHeight);
 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -102,7 +127,7 @@ R3f.w = PV1f.w;
 R2f.w = backupReg0f;
 PS0f = R2f.w;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/Pikmin3_Resolution/ec4a85d51e778437_0000000000000000_vs.txt
+++ b/Resolutions/Pikmin3_Resolution/ec4a85d51e778437_0000000000000000_vs.txt
@@ -1,17 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader ec4a85d51e778437
 // Used for: Scaling Blur Pass
 const float resXScale = float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight);
 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -74,7 +99,7 @@ PS1f = R2f.x;
 // 2
 R2f.w = PV1f.x;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem3 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
 // 0

--- a/Resolutions/Pikmin3_Resolution/rules.txt
+++ b/Resolutions/Pikmin3_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001012BC00,000500001012BD00,000500001012BE00,000500021012BD01,0
 name = Resolution
 path = "Pikmin 3/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Slashiee and Crementif.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/PokkenTournament_Resolution/b2fecd8319ee0096_0000000000079249_ps.txt
+++ b/Resolutions/PokkenTournament_Resolution/b2fecd8319ee0096_0000000000079249_ps.txt
@@ -1,20 +1,46 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader b2fecd8319ee0096
 // Used for: DoF In-game
 const float resXScale = float($width)*(float($gameWidth)/float($renderWidth))/float($gameWidth); 
 const float resYScale = float($height)/float($gameHeight);
 
+#ifdef VULKAN
+layout(set = 1, binding = 5) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[4];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4603800 res 960x720x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0xf413c800 res 120x72x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 4) uniform sampler2D textureUnitPS4;// Tex4 addr 0xf41f9800 res 480x288x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler4 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 5) uniform sampler2D textureUnitPS5;// Tex5 addr 0xf415c000 res 128x72x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler5 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 6) uniform sampler2D textureUnitPS6;// Tex6 addr 0xf4166800 res 128x72x1 dim 1 tm: 4 format 0816 compSel: 0 1 2 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler6 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[4];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(2, 1, 1) uniform sampler2D textureUnitPS2;
+TEXTURE_LAYOUT(4, 1, 2) uniform sampler2D textureUnitPS4;
+TEXTURE_LAYOUT(5, 1, 3) uniform sampler2D textureUnitPS5;
+TEXTURE_LAYOUT(6, 1, 4) uniform sampler2D textureUnitPS6;
 layout(location = 0) in vec4 passParameterSem130;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/PokkenTournament_Resolution/fe05aca8e186a5fd_0000000000000079_ps.txt
+++ b/Resolutions/PokkenTournament_Resolution/fe05aca8e186a5fd_0000000000000079_ps.txt
@@ -1,21 +1,45 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader fe05aca8e186a5fd
 // Used for: DoF backgrounds
 const float resXScale = float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight);
 
-layout(binding = 38, std140) uniform uniformBlockPS6
+UNIFORM_BUFFER_LAYOUT(38, 1, 2) uniform uniformBlockPS6
 {
 vec4 uf_blockPS6[1024];
 };
 
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x33659800 res 640x360x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem136;
 layout(location = 1) in vec4 passParameterSem130;
 layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/PokkenTournament_Resolution/rules.txt
+++ b/Resolutions/PokkenTournament_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101DF400,00050002101DF401,00050000101DF500
 name = Resolution
 path = "Pokken Tournament/Graphics/Resolution"
 description = Changes the resolution of the game. Native Render means that instead of the game rendering at 960x720, it is at a native 1280x720. Known issues: Bloom needs shader edits. Made by Slashiee.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/Runner2_Resolution/4fe1bb2bc0611f15_0000000000000079_ps.txt
+++ b/Resolutions/Runner2_Resolution/4fe1bb2bc0611f15_0000000000000079_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 4fe1bb2bc0611f15
 // Used for: Horizontal and vertical background blur
 float resScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[1];
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform ivec4 uf_remappedPS[1];
 uniform vec2 uf_fragCoordScale;
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+#endif
+// uf_fragCoordScale was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) out vec4 passPixelColor0;
 int clampFI32(int v)
 {
@@ -47,7 +73,7 @@ ivec4 ARi = ivec4(0);
 bool predResult = true;
 vec3 cubeMapSTM;
 int cubeMapFaceId;
-R0f = vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw);
+R0f = GET_FRAGCOORD();
 // 0
 PV0f.z = R0f.x + 0.5;
 PV0f.w = R0f.y + 0.5;

--- a/Resolutions/Runner2_Resolution/rules.txt
+++ b/Resolutions/Runner2_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001011AF00,0005000010136300,00050000101DD600
 name = Resolution
 path = "BIT.TRIP Presents... Runner2: Future Legend of Rhythm Alien/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Slashiee.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/SkylandersImaginators_Resolution/3fd22273e2306b43_0000000000000000_vs.txt
+++ b/Resolutions/SkylandersImaginators_Resolution/3fd22273e2306b43_0000000000000000_vs.txt
@@ -1,14 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 3fd22273e2306b43
 // Used for: Horizontal shadow edge smoothing 
 float resXScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[5];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -130,7 +153,7 @@ backupReg1f = R2f.y;
 R2f.xyz = vec3(backupReg0f,backupReg0f,backupReg0f) + vec3(R127f.w,R125f.x,R127f.z);
 R2f.w = backupReg1f + R125f.y;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem133 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/SkylandersImaginators_Resolution/73111ccc2ffa1907_0000000000000000_vs.txt
+++ b/Resolutions/SkylandersImaginators_Resolution/73111ccc2ffa1907_0000000000000000_vs.txt
@@ -1,14 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 73111ccc2ffa1907
 // Used for: Fixing shadow smoothing resolution
 float resXScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[6];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+};
+#else
+uniform ivec4 uf_remappedVS[6];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -105,7 +128,7 @@ R2f.x /= 2.0;
 R2f.y = intBitsToFloat(uf_remappedVS[5].w);
 R2f.y /= 2.0;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem134 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/SkylandersImaginators_Resolution/bc5cb1edf2b7da65_0000000000000000_vs.txt
+++ b/Resolutions/SkylandersImaginators_Resolution/bc5cb1edf2b7da65_0000000000000000_vs.txt
@@ -1,14 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader bc5cb1edf2b7da65
 // Used for: Vertical shadow edge smoothing
 float resYScale = float($height)/float($gameHeight);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[5];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -127,7 +150,7 @@ PS0f = R4f.y;
 R4f.z = R125f.x + R2f.y;
 R4f.w = R126f.y + R2f.y;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem133 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/SkylandersImaginators_Resolution/rules.txt
+++ b/Resolutions/SkylandersImaginators_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101F4D00,00050000101FB100
 name = Resolution
 path = "Skylanders Imaginators/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Crementif.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/SkylandersTrapTeam_Resolution/4f04d8903ea4256a_0000000000000079_ps.txt
+++ b/Resolutions/SkylandersTrapTeam_Resolution/4f04d8903ea4256a_0000000000000079_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 4f04d8903ea4256a
 // Used for: Horizontal bloom blur
 float resXScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[1];
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform ivec4 uf_remappedPS[1];
 uniform vec2 uf_fragCoordScale;
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+#endif
+// uf_fragCoordScale was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
 int clampFI32(int v)

--- a/Resolutions/SkylandersTrapTeam_Resolution/52c4522be0df98da_0000000000000000_vs.txt
+++ b/Resolutions/SkylandersTrapTeam_Resolution/52c4522be0df98da_0000000000000000_vs.txt
@@ -1,14 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 52c4522be0df98da
 // Used for: Fixing shadow resolution
 float resScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[6];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+};
+#else
+uniform ivec4 uf_remappedVS[6];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -109,7 +132,7 @@ R3f.x /= 2.0;
 R3f.y = intBitsToFloat(uf_remappedVS[5].w);
 R3f.y /= 2.0;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem133 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
 // export

--- a/Resolutions/SkylandersTrapTeam_Resolution/74681a5c2af57975_0000000000000079_ps.txt
+++ b/Resolutions/SkylandersTrapTeam_Resolution/74681a5c2af57975_0000000000000079_ps.txt
@@ -1,13 +1,39 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 74681a5c2af57975
 // Used for: Vertical bloom blur
 float resYScale = float($height)/float($gameHeight);
 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform ivec4 uf_remappedPS[1];
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform ivec4 uf_remappedPS[1];
 uniform vec2 uf_fragCoordScale;
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+#endif
+// uf_fragCoordScale was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
 int clampFI32(int v)

--- a/Resolutions/SkylandersTrapTeam_Resolution/b262de99418ca791_0000000000000000_vs.txt
+++ b/Resolutions/SkylandersTrapTeam_Resolution/b262de99418ca791_0000000000000000_vs.txt
@@ -1,14 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 52c4522be0df98da
 // Used for: Fixing shadow resolution
 float resScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[6];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+};
+#else
+uniform ivec4 uf_remappedVS[6];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -109,7 +132,7 @@ R3f.x /= 2.0;
 R3f.y = intBitsToFloat(uf_remappedVS[5].w);
 R3f.y /= 2.0;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem133 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
 // export

--- a/Resolutions/SkylandersTrapTeam_Resolution/b6bb4d6527f56601_0000000000000000_vs.txt
+++ b/Resolutions/SkylandersTrapTeam_Resolution/b6bb4d6527f56601_0000000000000000_vs.txt
@@ -1,14 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader b6bb4d6527f56601
 // Used for: Vertical shadow edge smoothing
 float resYScale = float($height)/float($gameHeight);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[5];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -127,7 +150,7 @@ PS0f = R4f.y;
 R4f.z = R125f.x + R2f.y;
 R4f.w = R126f.y + R2f.y;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem133 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/SkylandersTrapTeam_Resolution/e2a33ddb22abbc43_0000000000000000_vs.txt
+++ b/Resolutions/SkylandersTrapTeam_Resolution/e2a33ddb22abbc43_0000000000000000_vs.txt
@@ -1,14 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader e2a33ddb22abbc43
 // Used for: Horizontal shadow edge smoothing
 float resXScale = float($width)/float($gameWidth);
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[5];
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -130,7 +153,7 @@ backupReg1f = R2f.y;
 R2f.xyz = vec3(backupReg0f,backupReg0f,backupReg0f) + vec3(R127f.w,R125f.x,R127f.z);
 R2f.w = backupReg1f + R125f.y;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem133 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/SkylandersTrapTeam_Resolution/rules.txt
+++ b/Resolutions/SkylandersTrapTeam_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001017C600,0005000010181F00
 name = Resolution
 path = "Skylanders Trap Team/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Crementif.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/StarFoxZero_Resolution/43b6693ca98767b2_0000000000000079_ps.txt
+++ b/Resolutions/StarFoxZero_Resolution/43b6693ca98767b2_0000000000000079_ps.txt
@@ -1,11 +1,35 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 43b6693ca98767b2 - Gamepad AA
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4fa8800 res 854x480x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/StarFoxZero_Resolution/78a2659662685d55_0000000000000079_ps.txt
+++ b/Resolutions/StarFoxZero_Resolution/78a2659662685d55_0000000000000079_ps.txt
@@ -1,11 +1,35 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 78a2659662685d55 - TV AA
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4fa8800 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem133;
 layout(location = 0) out vec4 passPixelColor0;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
+uniform vec4 uf_fragCoordScale;
+};
+#else
 uniform vec2 uf_fragCoordScale;
+#endif
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Resolutions/StarFoxZero_Resolution/rules.txt
+++ b/Resolutions/StarFoxZero_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 00050000101B0400,00050000101B0500
 name = Resolution
 path = "Star Fox Zero/Graphics/Resolution"
 description = Changes the resolution of the game.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/SuperMarioMaker_Resolution/37a4ec1a7dbc7391_00000000000003c9_ps.txt
+++ b/Resolutions/SuperMarioMaker_Resolution/37a4ec1a7dbc7391_00000000000003c9_ps.txt
@@ -1,17 +1,43 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 37a4ec1a7dbc7391
 // Used for: Scaling Anti-Aliasing solution of game
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 2) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[4];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf45c6000 res 1280x720x1 dim 1 tm: 4 format 0019 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 1
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x1d28c000 res 1280x720x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 2 2 2 border: 1
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[4];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
 layout(location = 0) in vec4 passParameterSem2;
 layout(location = 0) out vec4 passPixelColor0;
 
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 float scaleAA = uf_fragCoordScale.x;
 
 int clampFI32(int v)

--- a/Resolutions/SuperMarioMaker_Resolution/rules.txt
+++ b/Resolutions/SuperMarioMaker_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001018DB00,000500001018DC00,000500001018DD00
 name = Resolution
 path = "Super Mario Maker/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Crementif.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/SuperSmashBros_Resolution/315d61ad21f97614_0000000000000000_vs.txt
+++ b/Resolutions/SuperSmashBros_Resolution/315d61ad21f97614_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 315d61ad21f97614
 // Used for: Vertical blur pass end screen background
 const float resXScale = (float($width)/float($gameWidth));
 const float resYScale = (float($height)/float($gameHeight));
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[5];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem2;
-layout(location = 2) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -112,7 +137,7 @@ R0f.w = PV1f.z + R2f.y;
 R3f.w = PV1f.x + R2f.y;
 PS0f = R3f.w;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem130 = vec4(R0f.x, R0f.y, R0f.x, R0f.w);
 // export

--- a/Resolutions/SuperSmashBros_Resolution/4b92e636153d6b54_0000000000000000_vs.txt
+++ b/Resolutions/SuperSmashBros_Resolution/4b92e636153d6b54_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 4b92e636153d6b54
 // Used for: Horizontal blur pass end screen background
 const float resXScale = (float($width)/float($gameWidth));
 const float resYScale = (float($height)/float($gameHeight));
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[5];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem2;
-layout(location = 2) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[5];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -112,7 +137,7 @@ R3f.w = R2f.x + PV1f.w;
 R3f.z = R2f.x + PV1f.x;
 PS0f = R3f.z;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem130 = vec4(R0f.x, R0f.y, R0f.z, R0f.y);
 // export

--- a/Resolutions/SuperSmashBros_Resolution/rules.txt
+++ b/Resolutions/SuperSmashBros_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010110E00,0005000010145000,0005000010144F00
 name = Resolution
 path = "Super Smash Bros. for Wii U/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Slashiee.
-version = 3
+version = 4
 
 [Preset]
 name = 1920x1080 (Default)

--- a/Resolutions/WindWakerHD_Resolution/1f83c0d47b1c4c34_0000000000000000_vs.txt
+++ b/Resolutions/WindWakerHD_Resolution/1f83c0d47b1c4c34_0000000000000000_vs.txt
@@ -1,16 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 1f83c0d47b1c4c34 //box downscale
 
 const float resXScale = (float($height)/float($gameHeight)); 
 const float resYScale = (float($width)/float($gameWidth)); 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -73,7 +98,7 @@ PS1f = R2f.x;
 // 2
 R2f.w = PV1f.x;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem3 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
 // 0

--- a/Resolutions/WindWakerHD_Resolution/4ffa96d07cd53c34_0000000000000000_vs.txt
+++ b/Resolutions/WindWakerHD_Resolution/4ffa96d07cd53c34_0000000000000000_vs.txt
@@ -1,7 +1,23 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 4ffa96d07cd53c34
 
 const float resXScale = (float($height)/float($gameHeight)); 
@@ -9,10 +25,19 @@ const float resYScale = (float($height)/float($gameHeight));
 
 
 //box low res (bloom?)
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -81,7 +106,7 @@ R0f.y = R127f.x;
 R0f.z = PV1f.z;
 R2f.w = PV1f.z;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem0 = vec4(R2f.x, R2f.y, R2f.x, R2f.w);
 // export

--- a/Resolutions/WindWakerHD_Resolution/842a19b509f8b91a_0000000000000000_vs.txt
+++ b/Resolutions/WindWakerHD_Resolution/842a19b509f8b91a_0000000000000000_vs.txt
@@ -1,15 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 842a19b509f8b91a //vertical pass bloom
 
 const float resYScale = (float($height)/float($gameHeight)); 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -92,7 +117,7 @@ PS1f = R2f.z;
 // 4
 R4f.xzw = vec3(R2f.x,PS1f,R2f.y);
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem0 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/WindWakerHD_Resolution/8d68a0e3561ff525_0000000000000000_vs.txt
+++ b/Resolutions/WindWakerHD_Resolution/8d68a0e3561ff525_0000000000000000_vs.txt
@@ -1,15 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 
 // shader 8d68a0e3561ff525 //horiztontal bloom pass
 const float resXScale = (float($width)/float($gameWidth)); 
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[1];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -90,7 +115,7 @@ R2f.y = backupReg0f + -(R126f.y);
 R2f.z = backupReg0f + R126f.y;
 R2f.w = backupReg0f;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 passParameterSem1 = vec4(R0f.x, R0f.y, R0f.z, R0f.w);
 // export

--- a/Resolutions/WindWakerHD_Resolution/rules.txt
+++ b/Resolutions/WindWakerHD_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010143400,0005000010143600,0005000010143500
 name = Resolution
 path = "The Legend of Zelda: The Wind Waker HD/Graphics/Resolution"
 description = Changes the resolution of the game. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = 1920x1080 Default

--- a/Resolutions/YoshisWoollyWorld_Resolution/b5082db8c1a44514_0000000000000079_ps.txt
+++ b/Resolutions/YoshisWoollyWorld_Resolution/b5082db8c1a44514_0000000000000079_ps.txt
@@ -1,25 +1,50 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader b5082db8c1a44514
 //BGblur vert
-const float dither = $dither ;
+const float dither = $dither;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterPS[256];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4e14800 res 640x360x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_uniformRegisterPS[256];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 
-highp float lineRand(vec2 co)
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
-
 
 int clampFI32(int v)
 {

--- a/Resolutions/YoshisWoollyWorld_Resolution/f1f99f18ae69719b_0000000000000079_ps.txt
+++ b/Resolutions/YoshisWoollyWorld_Resolution/f1f99f18ae69719b_0000000000000079_ps.txt
@@ -1,28 +1,50 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader f1f99f18ae69719b
 //Bg horizontal
-const float dither = $dither ;
+const float dither = $dither;
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_uniformRegisterPS[256];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf59d2000 res 640x360x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_uniformRegisterPS[256];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 
-
-highp float lineRand(vec2 co)
+float lineRand(vec2 co)
 {
-	highp float a = 12.9898;
-	highp float b = 78.233;
-	highp float c = 43758.5453;
-	highp float dt = dot(co.xy, vec2(a, b));
-	highp float sn = mod(dt, 3.14);
+	float a = 12.9898;
+	float b = 78.233;
+	float c = 43758.5453;
+	float dt = dot(co.xy, vec2(a, b));
+	float sn = mod(dt, 3.14);
 	return fract(sin(sn) * c);
 }
-
-
-//- (lineRand(R0i.xy )*0.415)
 
 int clampFI32(int v)
 {

--- a/Resolutions/YoshisWoollyWorld_Resolution/rules.txt
+++ b/Resolutions/YoshisWoollyWorld_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010131F00,0005000010184E00,0005000010184D00
 name = Resolution
 path = "Yoshi's Woolly World/Graphics/Resolution"
 description = Changes the resolution of the game. Made by Slashiee and getdls.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Resolutions/ZombiU_Resolution/9993b65e9eb6bb1d_0000000000000079_ps.txt
+++ b/Resolutions/ZombiU_Resolution/9993b65e9eb6bb1d_0000000000000079_ps.txt
@@ -1,16 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 9993b65e9eb6bb1d
 //aa
 const float resXScale = float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0xf4385000 res 1280x720x1 dim 1 tm: 4 format 0019 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem130;
 layout(location = 1) in vec4 passParameterSem134;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 	if( v == 0x7FFFFFFF )

--- a/Resolutions/ZombiU_Resolution/d121b990e877579c_0000000000079249_ps.txt
+++ b/Resolutions/ZombiU_Resolution/d121b990e877579c_0000000000079249_ps.txt
@@ -1,22 +1,48 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader d121b990e877579c
 //shadow penumbra
 const float resXScale = float($width)/float($gameWidth);
 const float resYScale = float($height)/float($gameHeight); 
 
+#ifdef VULKAN
+layout(set = 1, binding = 5) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[11];
-layout(binding = 11) uniform sampler2D textureUnitPS11;// Tex11 addr 0xf4001000 res 1280x720x1 dim 1 tm: 4 format 0019 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler11 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 12) uniform sampler2DShadow textureUnitPS12;// Tex12 addr 0x28638000 res 512x512x1 dim 1 tm: 4 format 0005 compSel: 0 0 0 0 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler12 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 13) uniform sampler2D textureUnitPS13;// Tex13 addr 0xf4385000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler13 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 14) uniform sampler2D textureUnitPS14;// Tex14 addr 0xf4e12000 res 1280x720x1 dim 1 tm: 4 format 001a compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler14 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 15) uniform sampler2D textureUnitPS15;// Tex15 addr 0x1407d800 res 1280x720x1 dim 1 tm: 4 format 080e compSel: 0 0 0 0 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler15 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[11];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(11, 1, 0) uniform sampler2D textureUnitPS11;
+TEXTURE_LAYOUT(12, 1, 1) uniform sampler2DShadow textureUnitPS12;
+TEXTURE_LAYOUT(13, 1, 2) uniform sampler2D textureUnitPS13;
+TEXTURE_LAYOUT(14, 1, 3) uniform sampler2D textureUnitPS14;
+TEXTURE_LAYOUT(15, 1, 4) uniform sampler2D textureUnitPS15;
 layout(location = 0) in vec4 passParameterSem130;
 layout(location = 1) in vec4 passParameterSem131;
 layout(location = 2) in vec4 passParameterSem132;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 	if( v == 0x7FFFFFFF )

--- a/Resolutions/ZombiU_Resolution/rules.txt
+++ b/Resolutions/ZombiU_Resolution/rules.txt
@@ -3,7 +3,7 @@ titleIds = 000500001010DD00,000500001010EF00,0005000010112300,000500001011A700,0
 name = Resolution
 path = "ZombiU/Graphics/Resolution"
 description = Changes the resolution of the game. Made by getdls.
-version = 3
+version = 4
 
 [Preset]
 name = 1280x720 (Default)

--- a/Workarounds/Bayonetta2_Portal/e1e83a29eef8fee8_0000000000000000_vs.txt
+++ b/Workarounds/Bayonetta2_Portal/e1e83a29eef8fee8_0000000000000000_vs.txt
@@ -1,15 +1,42 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader e1e83a29eef8fee8
 // Used for: Hiding the blue layer behind the portal that doesn't appear on the Wii U.
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[7];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
 uniform float uf_alphaTestRef;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem5;
+};
+#else
+uniform ivec4 uf_remappedVS[7];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+uniform float uf_alphaTestRef;
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+// uf_alphaTestRef was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem5;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -218,7 +245,7 @@ R1f.y = PV0f.x + 0.5;
 R1f.z = R0f.z;
 R1f.w = R0f.w;
 // export
-gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+SET_POSITION(vec4(0.0, 0.0, 0.0, 0.0));
 // export
 passParameterSem133 = vec4(0.0, 0.0, 0.0, 0.0);
 // export

--- a/Workarounds/Bayonetta2_Portal/rules.txt
+++ b/Workarounds/Bayonetta2_Portal/rules.txt
@@ -3,6 +3,6 @@ titleIds = 0005000010172600,0005000010172700,000500001011B900
 name = Hides weird blue texture by blue portals.
 path = "Bayonetta 2/Workarounds/Portal"
 description = Hides a weird blue layer by the blue portals that's also not visible on the original console. Made by Crementif.
-version = 3
+version = 4
 
 # For a visual comparison, see this album: https://imgur.com/a/4e3HMS2

--- a/Workarounds/ColorSplash_GreenCharactersTint/0111382add7112a8_000080007124924b_ps.txt
+++ b/Workarounds/ColorSplash_GreenCharactersTint/0111382add7112a8_000080007124924b_ps.txt
@@ -1,22 +1,50 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 0111382add7112a8
 // Used for: Removing green tint from characters.
 
 
+#ifdef VULKAN
+layout(set = 1, binding = 10) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[37];
 uniform float uf_alphaTestRef;
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x292e8000 res 144x225x1 dim 1 tm: 4 format 0433 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 6 6 2 border: 0
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x362be000 res 64x64x1 dim 1 tm: 4 format 0235 compSel: 0 1 4 5 mipView: 0x0 (num 0x7) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 0 0 2 border: 0
-layout(binding = 3) uniform sampler2D textureUnitPS3;// Tex3 addr 0x3686e000 res 64x64x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 0 mipView: 0x0 (num 0x7) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 0 0 2 border: 0
-layout(binding = 4) uniform sampler2D textureUnitPS4;// Tex4 addr 0x36870000 res 64x64x1 dim 1 tm: 4 format 0034 compSel: 0 0 0 5 mipView: 0x0 (num 0x7) sliceView: 0x0 (num 0x1) Sampler4 ClampX/Y/Z: 0 0 2 border: 0
-layout(binding = 6) uniform sampler2D textureUnitPS6;// Tex6 addr 0x29368000 res 138x223x1 dim 1 tm: 4 format 0433 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler6 ClampX/Y/Z: 6 6 2 border: 0
-layout(binding = 7) uniform sampler2D textureUnitPS7;// Tex7 addr 0x32daa000 res 64x64x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler7 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 10) uniform sampler2D textureUnitPS10;// Tex10 addr 0xf56c4800 res 1024x1024x1 dim 1 tm: 4 format 080e compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler10 ClampX/Y/Z: 6 6 6 border: 2
-layout(binding = 11) uniform sampler2D textureUnitPS11;// Tex11 addr 0xf5ac4800 res 1024x1024x1 dim 1 tm: 4 format 080e compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler11 ClampX/Y/Z: 6 6 6 border: 2
-layout(binding = 12) uniform sampler2D textureUnitPS12;// Tex12 addr 0xf5ec4800 res 512x512x1 dim 1 tm: 4 format 0001 compSel: 0 4 4 5 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x1) Sampler12 ClampX/Y/Z: 6 6 6 border: 2
-layout(binding = 15) uniform samplerCubeArray textureUnitPS15;// Tex15 addr 0x130dc000 res 128x128x1 dim 3 tm: 4 format 0033 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x6) Sampler15 ClampX/Y/Z: 2 2 2 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[37];
+uniform float uf_alphaTestRef;
+uniform vec2 uf_fragCoordScale;
+#endif
+// uf_alphaTestRef was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(2, 1, 1) uniform sampler2D textureUnitPS2;
+TEXTURE_LAYOUT(3, 1, 2) uniform sampler2D textureUnitPS3;
+TEXTURE_LAYOUT(4, 1, 3) uniform sampler2D textureUnitPS4;
+TEXTURE_LAYOUT(6, 1, 4) uniform sampler2D textureUnitPS6;
+TEXTURE_LAYOUT(7, 1, 5) uniform sampler2D textureUnitPS7;
+TEXTURE_LAYOUT(10, 1, 6) uniform sampler2D textureUnitPS10;
+TEXTURE_LAYOUT(11, 1, 7) uniform sampler2D textureUnitPS11;
+TEXTURE_LAYOUT(12, 1, 8) uniform sampler2D textureUnitPS12;
+TEXTURE_LAYOUT(15, 1, 9) uniform samplerCubeArray textureUnitPS15;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 2) in vec4 passParameterSem2;
@@ -31,7 +59,7 @@ layout(location = 1) out vec4 passPixelColor1;
 layout(location = 2) out vec4 passPixelColor2;
 layout(location = 3) out vec4 passPixelColor3;
 layout(location = 4) out vec4 passPixelColor4;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 void redcCUBE(vec4 src0, vec4 src1, out vec3 stm, out int faceId)
 {
 // stm -> x .. s, y .. t, z .. MajorAxis*2.0

--- a/Workarounds/ColorSplash_GreenCharactersTint/rules.txt
+++ b/Workarounds/ColorSplash_GreenCharactersTint/rules.txt
@@ -3,4 +3,4 @@ titleIds = 000500001F600900,000500001F600A00,000500001F600B00
 name = "Green Tinted Characters Workaround"
 path = "Paper Mario: Color Splash/Workarounds/Green Tinted Characters"
 description = Fixes the green tint on characters that occur randomly. Made by Crementif.
-version = 3
+version = 4

--- a/Workarounds/HyruleWarriors_DLCFix/rules.txt
+++ b/Workarounds/HyruleWarriors_DLCFix/rules.txt
@@ -1,6 +1,6 @@
 [Definition]
 titleIds = 000500001017D800,000500001017D900,000500001017CD00
-name = "Hyrule Warriors - DLC Crash Fix"
+name = DLC Crash Fix
 path = "Hyrule Warriors/Workarounds/DLC Crash Fix"
 description = Fixes game crashing with DLC installed.
-version = 3
+version = 4

--- a/Workarounds/HyruleWarriors_EnemyDeathFix/6e8a52b2c5236e90_0000000001fffe49_ps.txt
+++ b/Workarounds/HyruleWarriors_EnemyDeathFix/6e8a52b2c5236e90_0000000001fffe49_ps.txt
@@ -1,11 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 6e8a52b2c5236e90
+#ifdef VULKAN
+layout(set = 1, binding = 3) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[16];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x21304000 res 512x512x1 dim 1 tm: 4 format 0033 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 0 0 0 border: 0
-layout(binding = 1) uniform sampler2D textureUnitPS1;// Tex1 addr 0x212d7000 res 512x512x1 dim 1 tm: 4 format 0031 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler1 ClampX/Y/Z: 0 0 0 border: 0
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x21280000 res 512x512x1 dim 1 tm: 4 format 0433 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 0 0 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[16];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform sampler2D textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
 layout(location = 0) in vec4 passParameterSem64;
 layout(location = 1) in vec4 passParameterSem65;
 layout(location = 2) in vec4 passParameterSem66;
@@ -14,7 +40,7 @@ layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
 layout(location = 2) out vec4 passPixelColor2;
 layout(location = 3) out vec4 passPixelColor3;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Workarounds/HyruleWarriors_EnemyDeathFix/fcea74ffa264fa58_000000000ffff2c9_ps.txt
+++ b/Workarounds/HyruleWarriors_EnemyDeathFix/fcea74ffa264fa58_000000000ffff2c9_ps.txt
@@ -1,12 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader fcea74ffa264fa58
+#ifdef VULKAN
+layout(set = 1, binding = 4) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[18];
-layout(binding = 0) uniform sampler2D textureUnitPS0;// Tex0 addr 0x2178c000 res 512x512x1 dim 1 tm: 4 format 0033 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler0 ClampX/Y/Z: 0 0 0 border: 0
-layout(binding = 1) uniform samplerCubeArray textureUnitPS1;// Tex1 addr 0x1bb2c000 res 256x256x1 dim 3 tm: 4 format 0431 compSel: 0 1 2 3 mipView: 0x0 (num 0x1) sliceView: 0x0 (num 0x6) Sampler1 ClampX/Y/Z: 2 2 2 border: 0
-layout(binding = 2) uniform sampler2D textureUnitPS2;// Tex2 addr 0x2175f000 res 512x512x1 dim 1 tm: 4 format 0031 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler2 ClampX/Y/Z: 0 0 0 border: 0
-layout(binding = 3) uniform sampler2D textureUnitPS3;// Tex3 addr 0x21708000 res 512x512x1 dim 1 tm: 4 format 0433 compSel: 0 1 2 3 mipView: 0x0 (num 0x8) sliceView: 0x0 (num 0x1) Sampler3 ClampX/Y/Z: 0 0 0 border: 0
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[18];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
+TEXTURE_LAYOUT(1, 1, 1) uniform samplerCubeArray textureUnitPS1;
+TEXTURE_LAYOUT(2, 1, 2) uniform sampler2D textureUnitPS2;
+TEXTURE_LAYOUT(3, 1, 3) uniform sampler2D textureUnitPS3;
 layout(location = 0) in vec4 passParameterSem64;
 layout(location = 1) in vec4 passParameterSem65;
 layout(location = 2) in vec4 passParameterSem66;
@@ -15,7 +41,7 @@ layout(location = 0) out vec4 passPixelColor0;
 layout(location = 1) out vec4 passPixelColor1;
 layout(location = 2) out vec4 passPixelColor2;
 layout(location = 3) out vec4 passPixelColor3;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 void redcCUBE(vec4 src0, vec4 src1, out vec3 stm, out int faceId)
 {
 // stm -> x .. s, y .. t, z .. MajorAxis*2.0

--- a/Workarounds/HyruleWarriors_EnemyDeathFix/rules.txt
+++ b/Workarounds/HyruleWarriors_EnemyDeathFix/rules.txt
@@ -3,4 +3,4 @@ titleIds = 000500001017D800,000500001017D900,000500001017CD00
 name = "Hyrule Warriors - NVIDIA Enemy Death Fix"
 path = "Hyrule Warriors/Workarounds/NVIDIA Enemy Death Fix"
 description = Fixes graphics glitch and crashes due to enemy death.
-version = 3
+version = 4

--- a/Workarounds/SuperMarioMaker_GridFix/a2b3125cf46e9f74_0000000000000000_vs.txt
+++ b/Workarounds/SuperMarioMaker_GridFix/a2b3125cf46e9f74_0000000000000000_vs.txt
@@ -1,15 +1,40 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_packing : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader a2b3125cf46e9f74
 // Used for: Fixing the grid by inserting some values that are 0 on recompiler mode.
 
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[17];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem8;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[17];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem8;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -227,7 +252,7 @@ R4f.x = R126f.x * PS1f;
 R4f.y = R127f.y * PS1f;
 R4f.z = R126f.z * PS1f;
 // export
-gl_Position = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+SET_POSITION(vec4(R1f.x, R1f.y, R1f.z, R1f.w));
 // export
 // skipped export to semanticId 255
 // export

--- a/Workarounds/SuperMarioMaker_GridFix/rules.txt
+++ b/Workarounds/SuperMarioMaker_GridFix/rules.txt
@@ -3,4 +3,4 @@ titleIds = 000500001018DB00,000500001018DC00,000500001018DD00
 name = Grid Fix
 path = "Super Mario Maker/Workarounds/Grid Fix"
 description = Fixes the issue where the grid isn't rendered correctly and adds a tint to the image. Normally only there with interpreter. Made by Crementif.
-version = 3
+version = 4

--- a/Workarounds/SuperSmashBros_NoPixelMess/rules.txt
+++ b/Workarounds/SuperSmashBros_NoPixelMess/rules.txt
@@ -3,7 +3,7 @@ titleIds = 0005000010110E00,0005000010145000,0005000010144F00
 name = No "Pixel Mess"
 path = Super Smash Bros. for Wii U/Workarounds/No "Pixel Mess"
 description = Removes the "Pixel Mess" that appears on the results screen. Currently causes several effects to not appear. Made by Slashiee and Skalfate.
-version = 3
+version = 4
 
 # A screenshot of the issue can be seen here: https://cdn.discordapp.com/attachments/286429969104764928/335077383847673857/unknown.png
 

--- a/Workarounds/WiiU_eShop_RemoveGrayOverlay/fcd26205b94e11ca_000000000000001f_ps.txt
+++ b/Workarounds/WiiU_eShop_RemoveGrayOverlay/fcd26205b94e11ca_000000000000001f_ps.txt
@@ -1,13 +1,41 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
 uniform float uf_alphaTestRef;
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform float uf_alphaTestRef;
+uniform vec2 uf_fragCoordScale;
+#endif
+// uf_alphaTestRef was moved to the ufBlock
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Workarounds/WiiU_eShop_RemoveGrayOverlay/fcd26205b94e11ca_0000000000000079_ps.txt
+++ b/Workarounds/WiiU_eShop_RemoveGrayOverlay/fcd26205b94e11ca_0000000000000079_ps.txt
@@ -1,12 +1,38 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
+#ifdef VULKAN
+layout(set = 1, binding = 1) uniform ufBlock
+{
 uniform ivec4 uf_remappedPS[2];
-layout(binding = 0) uniform sampler2D textureUnitPS0;
+uniform vec4 uf_fragCoordScale;
+};
+#else
+uniform ivec4 uf_remappedPS[2];
+uniform vec2 uf_fragCoordScale;
+#endif
+TEXTURE_LAYOUT(0, 1, 0) uniform sampler2D textureUnitPS0;
 layout(location = 0) in vec4 passParameterSem0;
 layout(location = 1) in vec4 passParameterSem1;
 layout(location = 0) out vec4 passPixelColor0;
-uniform vec2 uf_fragCoordScale;
+// uf_fragCoordScale was moved to the ufBlock
 int clampFI32(int v)
 {
 if( v == 0x7FFFFFFF )

--- a/Workarounds/WiiU_eShop_RemoveGrayOverlay/rules.txt
+++ b/Workarounds/WiiU_eShop_RemoveGrayOverlay/rules.txt
@@ -3,4 +3,4 @@ titleIds = 000500301001400a,000500301001410a,000500301001420a
 name = Remove Gray Overlay
 path = "Wii U/Nintendo eShop/Workarounds/Remove Gray Overlay"
 description = Hides the gray overlay covering the lower half of the screen. Made by Exzap.
-version = 3
+version = 4

--- a/Workarounds/Wonderful101_ShadowRemoval/2a8afa64e98f2977_0000000000000000_vs.txt
+++ b/Workarounds/Wonderful101_ShadowRemoval/2a8afa64e98f2977_0000000000000000_vs.txt
@@ -1,27 +1,44 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 2a8afa64e98f2977
-layout(binding = 1, std140) uniform uniformBlockVS1
+UNIFORM_BUFFER_LAYOUT(1, 0, 1) uniform uniformBlockVS1
 {
 vec4 uf_blockVS1[1024];
 };
 
-layout(binding = 2, std140) uniform uniformBlockVS2
+UNIFORM_BUFFER_LAYOUT(2, 0, 2) uniform uniformBlockVS2
 {
 vec4 uf_blockVS2[1024];
 };
 
-layout(binding = 4, std140) uniform uniformBlockVS4
+UNIFORM_BUFFER_LAYOUT(4, 0, 3) uniform uniformBlockVS4
 {
 vec4 uf_blockVS4[1024];
 };
 
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem1;
-layout(location = 2) in uvec4 attrDataSem2;
-layout(location = 3) in uvec4 attrDataSem3;
+
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -391,7 +408,7 @@ PV1i.z = tempi.x;
 PV1i.w = tempi.x;
 R4i.w = tempi.x;
 // export
-gl_Position = vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w));
+SET_POSITION(vec4(intBitsToFloat(R4i.x), intBitsToFloat(R4i.y), intBitsToFloat(R4i.z), intBitsToFloat(R4i.w)));
 // export
 // skipped export to semanticId 255
 // 0

--- a/Workarounds/Wonderful101_ShadowRemoval/5c0d907ed99903ab_0000000000000000_vs.txt
+++ b/Workarounds/Wonderful101_ShadowRemoval/5c0d907ed99903ab_0000000000000000_vs.txt
@@ -1,11 +1,37 @@
 #version 420
 #extension GL_ARB_texture_gather : enable
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale.xy,gl_FragCoord.zw)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#define GET_FRAGCOORD() vec4(gl_FragCoord.xy*uf_fragCoordScale,gl_FragCoord.zw)
+#endif
+// This shader was automatically converted to be cross-compatible with Vulkan and OpenGL.
+
 // shader 5c0d907ed99903ab
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
 uniform ivec4 uf_remappedVS[9];
-uniform vec2 uf_windowSpaceToClipSpaceTransform;
-layout(location = 0) in uvec4 attrDataSem0;
-layout(location = 1) in uvec4 attrDataSem3;
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+};
+#else
+uniform ivec4 uf_remappedVS[9];
+// uniform vec2 uf_windowSpaceToClipSpaceTransform; // Cemu optimized this uf_variable away in Cemu 1.15.7
+#endif
+// uf_windowSpaceToClipSpaceTransform was moved to the ufBlock
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem3;
 out gl_PerVertex
 {
 	vec4 gl_Position;
@@ -190,7 +216,7 @@ PV1i.z = tempi.x;
 PV1i.w = tempi.x;
 R2i.w = tempi.x;
 // export
-gl_Position = vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w));
+SET_POSITION(vec4(intBitsToFloat(R2i.x), intBitsToFloat(R2i.y), intBitsToFloat(R2i.z), intBitsToFloat(R2i.w)));
 // export
 // skipped export to semanticId 255
 // 0

--- a/Workarounds/Wonderful101_ShadowRemoval/rules.txt
+++ b/Workarounds/Wonderful101_ShadowRemoval/rules.txt
@@ -3,4 +3,4 @@ titleIds = 0005000010116300,000500001012DC00,0005000010135300
 name = Shadow Removal
 path = "The Wonderful 101/Workarounds/Shadow Removal"
 description = This removes all broken shadows.
-version = 3
+version = 4


### PR DESCRIPTION
Didn't update the docs (will do that tomorrow), but I manually checked (didn't verify them with the script but I did check if there wasn't anything too crazy that might screw things up and if there were any other signs that lead to issues) each pack to make sure that all the included ones are 99% safe.

I also didn't convert 5 graphic packs since they contained signs that needed to be manually checked or at least examined more:
- \Enhancements\TwilightPrincessHD_Bicubic (weird filter shenanigans)
- \Resolutions\DevilsThird_Resolution
- \Resolutions\TwilightPrincessHD_Resolution (this one just needs to be fully verified since it's popular enough and has like 27 shaders)
- \Resolutions\LegoStarWars_Resolution
- \Resolutions\TokyoMirage_Resolution (this one could also be verified with the script)

~~I hope I didn't make too many mistakes here.~~