### PR TITLE
Pictograph fix

### DIFF
--- a/Resolutions/WindWakerHD_Resolution/rules.txt
+++ b/Resolutions/WindWakerHD_Resolution/rules.txt
@@ -356,20 +356,21 @@ height = 33
 overwriteWidth = ($width/$gameWidth) * (60)
 overwriteHeight = ($height/$gameHeight) * (33)
 
-### pictograph. If you try to fix this, verify that saved pictures can be loaded from album.
 [TextureRedefine] #Pictograph
 width = 1600
 height = 912
 formats = 0x019
-overwriteWidth = ($width/$gameWidth) * 1600
+overwriteWidth = ($height/$gameHeight) * 1600
 overwriteHeight = ($height/$gameHeight) * 912
 
 [TextureRedefine] #Pictograph
 width = 1600
 height = 900
 formats = 0x019
-overwriteWidth = ($width/$gameWidth) * 1600
+overwriteWidth = ($height/$gameHeight) * 1600
 overwriteHeight = ($height/$gameHeight) * 900
+
+### pictograph. If you try to fix this, verify that saved pictures can be loaded from album.
 #
 #[TextureRedefine] #pictograph
 #width = 832

--- a/Resolutions/WindWakerHD_Resolution/rules.txt
+++ b/Resolutions/WindWakerHD_Resolution/rules.txt
@@ -357,20 +357,19 @@ overwriteWidth = ($width/$gameWidth) * (60)
 overwriteHeight = ($height/$gameHeight) * (33)
 
 ### pictograph. If you try to fix this, verify that saved pictures can be loaded from album.
-#
-#[TextureRedefine] #Pictograph
-#width = 1600
-#height = 912
-#formats = 0x019
-#overwriteWidth = ($width/$gameWidth) * 1600
-#overwriteHeight = ($height/$gameHeight) * 912
-#
-#[TextureRedefine] #Pictograph
-#width = 1600
-#height = 900
-#formats = 0x019
-#overwriteWidth = ($width/$gameWidth) * 1600
-#overwriteHeight = ($height/$gameHeight) * 900
+[TextureRedefine] #Pictograph
+width = 1600
+height = 912
+formats = 0x019
+overwriteWidth = ($width/$gameWidth) * 1600
+overwriteHeight = ($height/$gameHeight) * 912
+
+[TextureRedefine] #Pictograph
+width = 1600
+height = 900
+formats = 0x019
+overwriteWidth = ($width/$gameWidth) * 1600
+overwriteHeight = ($height/$gameHeight) * 900
 #
 #[TextureRedefine] #pictograph
 #width = 832


### PR DESCRIPTION
Using just that part of the code, the camera returned to working properly at resolutions lower than 1080p, on ultrawide resolutions it remains the same before this fix.

Video showing the fix:https://streamable.com/ovtvvg