### PR TITLE
[Paper Mario: CS] Fix the invisible characters in Cutout Mode

### DIFF
--- a/Workarounds/ColorSplash_InvisibleCharactersCutoutMode/f98d1c67b6e7d097_0000000000000000_vs.txt
+++ b/Workarounds/ColorSplash_InvisibleCharactersCutoutMode/f98d1c67b6e7d097_0000000000000000_vs.txt
@@ -1,0 +1,106 @@
+#version 430
+#extension GL_ARB_texture_gather : enable
+#extension GL_ARB_separate_shader_objects : enable
+// shader f98d1c67b6e7d097
+// start of shader inputs/outputs, predetermined by Cemu. Do not touch
+#ifdef VULKAN
+#define ATTR_LAYOUT(__vkSet, __location) layout(set = __vkSet, location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation, std140)
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(set = __vkSet, binding = __vkLocation)
+#define gl_VertexID gl_VertexIndex
+#define gl_InstanceID gl_InstanceIndex
+#define SET_POSITION(_v) gl_Position = _v; gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0
+#else
+#define ATTR_LAYOUT(__vkSet, __location) layout(location = __location)
+#define UNIFORM_BUFFER_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation, std140) 
+#define TEXTURE_LAYOUT(__glLocation, __vkSet, __vkLocation) layout(binding = __glLocation)
+#define SET_POSITION(_v) gl_Position = _v
+#endif
+#ifdef VULKAN
+layout(set = 0, binding = 0) uniform ufBlock
+{
+uniform ivec4 uf_remappedVS[1];
+};
+#else
+uniform ivec4 uf_remappedVS[1];
+#endif
+ATTR_LAYOUT(0, 0) in uvec4 attrDataSem0;
+ATTR_LAYOUT(0, 1) in uvec4 attrDataSem1;
+ATTR_LAYOUT(0, 2) in uvec4 attrDataSem2;
+ATTR_LAYOUT(0, 3) in uvec4 attrDataSem3;
+out gl_PerVertex
+{
+	vec4 gl_Position;
+};
+layout(location = 2) out vec4 passParameterSem2;
+layout(location = 1) out vec4 passParameterSem1;
+layout(location = 0) out vec4 passParameterSem0;
+layout(location = 3) out vec4 passParameterSem3;
+// end of shader inputs/outputs
+int clampFI32(int v)
+{
+if( v == 0x7FFFFFFF )
+	return floatBitsToInt(1.0);
+else if( v == 0xFFFFFFFF )
+	return floatBitsToInt(0.0);
+return floatBitsToInt(clamp(intBitsToFloat(v), 0.0, 1.0));
+}
+float mul_nonIEEE(float a, float b){ if( a == 0.0 || b == 0.0 ) return 0.0; return a*b; }
+void main()
+{
+vec4 R0f = vec4(0.0);
+vec4 R1f = vec4(0.0);
+vec4 R2f = vec4(0.0);
+vec4 R3f = vec4(0.0);
+vec4 R4f = vec4(0.0);
+uvec4 attrDecoder;
+float backupReg0f, backupReg1f, backupReg2f, backupReg3f, backupReg4f;
+vec4 PV0f = vec4(0.0), PV1f = vec4(0.0);
+float PS0f = 0.0, PS1f = 0.0;
+vec4 tempf = vec4(0.0);
+float tempResultf;
+int tempResulti;
+ivec4 ARi = ivec4(0);
+bool predResult = true;
+vec3 cubeMapSTM;
+int cubeMapFaceId;
+R0f = floatBitsToInt(ivec4(gl_VertexID, 0, 0, gl_InstanceID));
+attrDecoder.xyz = attrDataSem0.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R3f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xyzw = floatBitsToUint(vec4(attrDataSem1.xyzw)/255.0);
+R1f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(int(attrDecoder.w)));
+attrDecoder.xyz = attrDataSem2.xyz;
+attrDecoder.xyz = (attrDecoder.xyz>>24)|((attrDecoder.xyz>>8)&0xFF00)|((attrDecoder.xyz<<8)&0xFF0000)|((attrDecoder.xyz<<24));
+attrDecoder.w = 0;
+R4f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(floatBitsToInt(1.0)));
+attrDecoder.xyzw = floatBitsToUint(vec4(attrDataSem3.xyzw)/255.0);
+R2f = vec4(intBitsToFloat(int(attrDecoder.x)), intBitsToFloat(int(attrDecoder.y)), intBitsToFloat(int(attrDecoder.z)), intBitsToFloat(int(attrDecoder.w)));
+// 0
+backupReg0f = R3f.z;
+R0f.x = intBitsToFloat(uf_remappedVS[0].x) * 1.0;
+R0f.y = mul_nonIEEE(R1f.w, intBitsToFloat(uf_remappedVS[0].x));
+PV0f.z = -(R3f.y);
+PV0f.z *= 2.0;
+PV0f.w = R3f.x;
+PV0f.w *= 2.0;
+R3f.z = backupReg0f;
+PS0f = R3f.z;
+// 1
+R3f.x = PV0f.w + -(1.0);
+R3f.y = PV0f.z + 1.0;
+R0f.z = R4f.x;
+R0f.w = R4f.y;
+// export
+// Fix: Shader z position set to 1
+SET_POSITION(vec4(R3f.x, R3f.y, 1, R3f.w));
+// export
+passParameterSem2 = vec4(R2f.x, R2f.y, R2f.z, R2f.w);
+// export
+passParameterSem1 = vec4(R1f.x, R1f.y, R1f.z, R1f.w);
+// export
+passParameterSem0 = vec4(R0f.x, R0f.x, R0f.x, R0f.y);
+// export
+passParameterSem3 = vec4(R0f.z, R0f.w, R0f.z, R0f.z);
+}

--- a/Workarounds/ColorSplash_InvisibleCharactersCutoutMode/rules.txt
+++ b/Workarounds/ColorSplash_InvisibleCharactersCutoutMode/rules.txt
@@ -2,5 +2,5 @@
 titleIds = 000500001F600900,000500001F600A00,000500001F600B00
 name = "Invisible Characters in Cutout Mode Workaround"
 path = "Paper Mario: Color Splash/Workarounds/Invisible Characters in Cutout Mode"
-description = Fixes the problem of Mario and the flag not rendering during Cutout sequences.
+description = Fixes the problem of Mario and the flag not rendering during Cutout sequences. Made by RedHalted.
 version = 4

--- a/Workarounds/ColorSplash_InvisibleCharactersCutoutMode/rules.txt
+++ b/Workarounds/ColorSplash_InvisibleCharactersCutoutMode/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 000500001F600900,000500001F600A00,000500001F600B00
+name = "Invisible Characters in Cutout Mode Workaround"
+path = "Paper Mario: Color Splash/Workarounds/Invisible Characters in Cutout Mode"
+description = Fixes the problem of Mario and the flag not rendering during Cutout sequences.
+version = 4


### PR DESCRIPTION
This is a small fix to render Mario and the flag over the background during cutouts sequences. 

[Example](https://gfycat.com/soulfuldistortedcaribou).