### PR TITLE
Additional Splatoon Patches

### DIFF
--- a/Mods/Splatoon_BetterSquidSistersLighting/patches.txt
+++ b/Mods/Splatoon_BetterSquidSistersLighting/patches.txt
@@ -1,0 +1,4 @@
+[Gambit272]
+moduleMatches = 0xF7A78809
+
+0x100F4B18 = nop # Disables "MainNews" lighting

--- a/Mods/Splatoon_BetterSquidSistersLighting/rules.txt
+++ b/Mods/Splatoon_BetterSquidSistersLighting/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010176900,0005000010176A00,0005000010162B00
+name = Better Squid Sisters
+path = "Splatoon/Mods/Better Squid Sisters"
+description = Makes the Squid Sisters have realistic/somewhat better lighting in the news. Made by IVy.
+version = 4

--- a/Mods/Splatoon_BetterSquidSistersLighting/rules.txt
+++ b/Mods/Splatoon_BetterSquidSistersLighting/rules.txt
@@ -1,6 +1,6 @@
 [Definition]
 titleIds = 0005000010176900,0005000010176A00,0005000010162B00
-name = Better Squid Sisters
-path = "Splatoon/Mods/Better Squid Sisters"
-description = Makes the Squid Sisters have realistic/somewhat better lighting in the news. Made by IVy.
+name = Better Squid Sisters Lighting
+path = "Splatoon/Mods/Better Squid Sisters Lighting"
+description = Makes the Squid Sisters have "somewhat" better lighting when announcing the news. Made by IVy.
 version = 4

--- a/Mods/Splatoon_Remove2DNewsLayer/patches.txt
+++ b/Mods/Splatoon_Remove2DNewsLayer/patches.txt
@@ -1,0 +1,4 @@
+[Gambit272]
+moduleMatches = 0xF7A78809
+
+0x100980F8 = nop # Disables "2D(PlazaNews)"

--- a/Mods/Splatoon_Remove2DNewsLayer/rules.txt
+++ b/Mods/Splatoon_Remove2DNewsLayer/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010176900,0005000010176A00,0005000010162B00
+name = Remove 2D News Layer
+path = "Splatoon/Mods/Remove 2D News Layer"
+description = Removes the box around the news TV. Made by IVy.
+version = 4

--- a/Mods/Splatoon_SpecialSwap/patches.txt
+++ b/Mods/Splatoon_SpecialSwap/patches.txt
@@ -7,13 +7,10 @@ moduleMatches = 0xF7A78809
 
 0x1005C098 = .string "Wsp_BigLaser" # Original "Wsp_BigLaser"
 
-0x1001BA18 = .string "Wsp_%s_Bomb_Throw" # Original: "Wsp_%s_Bomb_Throw"
-
 0x100C237C = .string "Wsp_Shachihoko" # Original: "Wsp_Shachihoko"
 
 # Specials List
 
 # "Wsp_Tornado" is the Inkstrike
 # "Wsp_BigLaser" is the Killer Wail
-# "Wsp_%s_Bomb_Throw" is any Bomb Rush
 # "Wsp_Shachihoko" is the Rainmaker

--- a/Mods/Splatoon_SpecialSwap/patches.txt
+++ b/Mods/Splatoon_SpecialSwap/patches.txt
@@ -1,7 +1,7 @@
 [Gambit272]
 moduleMatches = 0xF7A78809
 
-# Special Swapper
+# Special Swapper Patch
 
 0x1005BBDC = .string "Wsp_Tornado" # Original: "Wsp_Tornado"
 

--- a/Mods/Splatoon_SpecialSwap/patches.txt
+++ b/Mods/Splatoon_SpecialSwap/patches.txt
@@ -11,18 +11,9 @@ moduleMatches = 0xF7A78809
 
 0x100C237C = .string "Wsp_Shachihoko" # Original: "Wsp_Shachihoko"
 
-# 0x100EBF1B = .string "tWsp_KingSquid" # Original: "tWsp_KingSquid" (experimental, not tested)
-
-# 0x100EA608 = .string "Barrier" # Original: "Barrier" (experimental, not tested)
-
-# 0x100EA610 = .string "SuperShot" # Original: "SuperShot" (experimental, not tested)
-
 # Specials List
 
 # "Wsp_Tornado" is the Inkstrike
 # "Wsp_BigLaser" is the Killer Wail
 # "Wsp_%s_Bomb_Throw" is any Bomb Rush
-# "tWsp_KingSquid" is probably the Kraken?
-# "Barrier" is the Bubbler
-# "SuperShot" is the Inkzooka
 # "Wsp_Shachihoko" is the Rainmaker

--- a/Mods/Splatoon_SpecialSwap/patches.txt
+++ b/Mods/Splatoon_SpecialSwap/patches.txt
@@ -9,6 +9,23 @@ moduleMatches = 0xF7A78809
 
 0x1001BA18 = .string "Wsp_%s_Bomb_Throw" # Original: "Wsp_%s_Bomb_Throw"
 
+0x100C237C = .string "Wsp_Shachihoko" # Original: "Wsp_Shachihoko"
+
+# 0x100EBF1B = .string "tWsp_KingSquid" # Original: "tWsp_KingSquid" (experimental, not tested)
+
+# 0x100EA608 = .string "Barrier" # Original: "Barrier" (experimental, not tested)
+
+# 0x100EA610 = .string "SuperShot" # Original: "SuperShot" (experimental, not tested)
+
+# 0x100EA61C = .string "FreeBombs" # Original: "FreeBombs" (experimental, not tested)
+
 # Specials List
 
-# All are listed above except for "Wsp_Shachihoko" which is the rainmaker
+# "Wsp_Tornado" is the Inkstrike
+# "Wsp_BigLaser" is the Killer Wail
+# "Wsp_%s_Bomb_Throw" is any Bomb Rush
+# "tWsp_KingSquid" is probably the Kraken?
+# "Barrier" is the Bubbler
+# "SuperShot" is the Inkzooka
+# "FreeBombs" might be an alternate Bomb Rush?
+# "Wsp_Shachihoko" is the Rainmaker

--- a/Mods/Splatoon_SpecialSwap/patches.txt
+++ b/Mods/Splatoon_SpecialSwap/patches.txt
@@ -17,8 +17,6 @@ moduleMatches = 0xF7A78809
 
 # 0x100EA610 = .string "SuperShot" # Original: "SuperShot" (experimental, not tested)
 
-# 0x100EA61C = .string "FreeBombs" # Original: "FreeBombs" (experimental, not tested)
-
 # Specials List
 
 # "Wsp_Tornado" is the Inkstrike
@@ -27,5 +25,4 @@ moduleMatches = 0xF7A78809
 # "tWsp_KingSquid" is probably the Kraken?
 # "Barrier" is the Bubbler
 # "SuperShot" is the Inkzooka
-# "FreeBombs" might be an alternate Bomb Rush?
 # "Wsp_Shachihoko" is the Rainmaker

--- a/Mods/Splatoon_SpecialSwap/patches.txt
+++ b/Mods/Splatoon_SpecialSwap/patches.txt
@@ -1,0 +1,14 @@
+[Gambit272]
+moduleMatches = 0xF7A78809
+
+# Special Swapper
+
+0x1005BBDC = .string "Wsp_Tornado" # Original: "Wsp_Tornado"
+
+0x1005C098 = .string "Wsp_BigLaser" # Original "Wsp_BigLaser"
+
+0x1001BA18 = .string "Wsp_%s_Bomb_Throw" # Original: "Wsp_%s_Bomb_Throw"
+
+# Specials List
+
+# All are listed above except for "Wsp_Shachihoko" which is the rainmaker

--- a/Mods/Splatoon_SpecialSwap/rules.txt
+++ b/Mods/Splatoon_SpecialSwap/rules.txt
@@ -2,5 +2,5 @@
 titleIds = 0005000010176900,0005000010176A00,0005000010162B00
 name = Special Swap
 path = "Splatoon/Mods/Special Swap"
-description = See patches.txt for more info. Made by IVy.
+description = See patches.txt for more info. Note: This patch is meant for the specials to be swapped with the Rainmaker, doing anything differently could cause instability and crashes. Made by IVy.
 version = 4

--- a/Mods/Splatoon_SpecialSwap/rules.txt
+++ b/Mods/Splatoon_SpecialSwap/rules.txt
@@ -1,6 +1,6 @@
 [Definition]
 titleIds = 0005000010176900,0005000010176A00,0005000010162B00
-name = Special Swapper
-path = "Splatoon/Mods/Special Swapper"
+name = Special Swap
+path = "Splatoon/Mods/Special Swap"
 description = See patches.txt for more info. Made by IVy.
 version = 4

--- a/Mods/Splatoon_SpecialSwap/rules.txt
+++ b/Mods/Splatoon_SpecialSwap/rules.txt
@@ -1,0 +1,6 @@
+[Definition]
+titleIds = 0005000010176900,0005000010176A00,0005000010162B00
+name = Special Swapper
+path = "Splatoon/Mods/Special Swapper"
+description = See patches.txt for more info. Made by IVy.
+version = 4


### PR DESCRIPTION
The "Better Squid Sisters Lighting" patch just removes the normal news lighting so it's set to what it would normally look like in that position in the plaza, making it look "somewhat" better. This also includes a patch the removal of the 2D news layer, and a special swapper, all made by me.